### PR TITLE
Update S3 Hash Function

### DIFF
--- a/lib/s3.js
+++ b/lib/s3.js
@@ -11,7 +11,8 @@
 *     keyStart: 'editor/',
 *     acl: 'public-read',
 *     accessKey: 'YOUR-AMAZON-S3-PUBLIC-ACCESS-KEY',
-*     secretKey: 'YOUR-AMAZON-S3-SECRET-ACCESS-KEY'
+*     secretKey: 'YOUR-AMAZON-S3-SECRET-ACCESS-KEY',
+*     sessionToken: 'YOUR_AWS_SESSION_TOKEN (required if using temporary credentials)'
 *   }
 *
 * @return:
@@ -25,7 +26,8 @@
 *       'x-amz-algorithm': 'AWS4-HMAC-SHA256',
 *       'x-amz-credential': xAmzCredential,
 *       'x-amz-date': xAmzDate,
-*       'x-amz-signature': signature
+*       'x-amz-signature': signature,
+*       'x-amz-security-token': sessionToken (if using temporary credentials)
 *     }
 *   }
 */
@@ -44,6 +46,7 @@ function getHash(config) {
   // These can be found on your Account page, under Security Credentials > Access Keys.
   var accessKeyId = config.accessKey;
   var secret = config.secretKey;
+  var sessionToken = config.sessionToken;
 
   var date = new Date().toISOString();
   var dateString = date.substr(0, 4) + date.substr(5, 2) + date.substr(8, 2); // Ymd format.
@@ -66,6 +69,11 @@ function getHash(config) {
       ['starts-with', '$Content-Type', ''] // accept all files
     ],
   }
+  
+  if (sessionToken) {
+    policy.conditions.push({'x-amz-security-token': sessionToken});
+  }
+  
   var policyBase64 = new Buffer(JSON.stringify(policy)).toString('base64');
 
 
@@ -81,10 +89,9 @@ function getHash(config) {
   var signingKey = hmac(dateRegionServiceKey, 'aws4_request');
   var signature = hmac(signingKey, policyBase64).toString('hex');
 
-
-  return {
+  const hash = {
     bucket: bucket,
-    region: region != 'us-east-1' ? 's3-' + region : 's3',
+    region: region != 'us-east-1' ? 's3.' + region : 's3',
     keyStart: keyStart,
     params: {
       acl: acl,
@@ -94,8 +101,13 @@ function getHash(config) {
       'x-amz-date': xAmzDate,
       'x-amz-signature': signature
     }
+  };
+  
+  if (sessionToken) {
+    hash.params['x-amz-security-token'] = sessionToken;
   }
 
+  return hash
 }
 
 exports.S3 = {


### PR DESCRIPTION
Updated S3 endpoints from 's3-{region}' to 's3.{region}'. Ref: https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region

Added 'x-amz-security-token' support temporary credentials.