### PR TITLE
2554: Node JS SDK - Image upload throwing error for "By Url and Upload Image" for 2nd and 3rd section of Editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Easing the [Froala WYSIWYG HTML Editor](https://github.com/froala/wysiwyg-editor) server side integration in Node.JS projects.
 
 ## Prerequisite
-1. ImageMagick must be installed.
+1. ImageMagick must be installed. Note: It must be installed with "Install legacy utilities" option checked during the setup.
 
 ## Installation
 


### PR DESCRIPTION
Fix: Added correct installation steps to Readme markdown file.