### PR TITLE
Real-time Collaboration, Version History & Collaborative Demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ bower_components
 examples/uploads
 npm-debug.log
 **/.DS_STORE
+package-lock.json
+collab.db**

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ examples/uploads
 npm-debug.log
 **/.DS_STORE
 package-lock.json
-collab.db**
+collab.db*

--- a/examples/collaborative/editor.html
+++ b/examples/collaborative/editor.html
@@ -1,0 +1,222 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Collaborative Plugin — Editor</title>
+
+  <script src="/bower_components/jquery/dist/jquery.min.js">
+    </script>
+
+    <!-- Include Font Awesome. -->
+    <link href="/bower_components/font-awesome/css/fontawesome.min.css" rel="stylesheet" type="text/css" />
+
+    <!-- Include Froala Editor styles -->
+    <link rel="stylesheet" href="/bower_components/froala-wysiwyg-editor/css/froala_editor.min.css" />
+    <link rel="stylesheet" href="/bower_components/froala-wysiwyg-editor/css/froala_style.min.css" />
+
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.4.0/css/font-awesome.min.css">
+    <link rel="stylesheet" href="/bower_components/froala-wysiwyg-editor/css/froala_editor.css">
+    <link rel="stylesheet" href="/bower_components/froala-wysiwyg-editor/css/froala_style.css">
+    <link rel="stylesheet" href="/bower_components/froala-wysiwyg-editor/css/plugins/ai_assist.css">
+    <link rel="stylesheet" href="/bower_components/froala-wysiwyg-editor/css/plugins/code_view.css">
+    <link rel="stylesheet" href="/bower_components/froala-wysiwyg-editor/css/plugins/draggable.css">
+    <link rel="stylesheet" href="/bower_components/froala-wysiwyg-editor/css/plugins/colors.css">
+    <link rel="stylesheet" href="/bower_components/froala-wysiwyg-editor/css/plugins/emoticons.css">
+    <link rel="stylesheet" href="/bower_components/froala-wysiwyg-editor/css/plugins/image_manager.css">
+    <link rel="stylesheet" href="/bower_components/froala-wysiwyg-editor/css/plugins/image.css">
+    <link rel="stylesheet" href="/bower_components/froala-wysiwyg-editor/css/plugins/line_breaker.css">
+    <link rel="stylesheet" href="/bower_components/froala-wysiwyg-editor/css/plugins/table.css">
+    <link rel="stylesheet" href="/bower_components/froala-wysiwyg-editor/css/plugins/char_counter.css">
+    <link rel="stylesheet" href="/bower_components/froala-wysiwyg-editor/css/plugins/video.css">
+    <link rel="stylesheet" href="/bower_components/froala-wysiwyg-editor/css/plugins/fullscreen.css">
+    <link rel="stylesheet" href="/bower_components/froala-wysiwyg-editor/css/plugins/file.css">
+    <link rel="stylesheet" href="/bower_components/froala-wysiwyg-editor/css/plugins/quick_insert.css">
+    <link rel="stylesheet" href="/bower_components/froala-wysiwyg-editor/css/plugins/help.css">
+    <link rel="stylesheet" href="/bower_components/froala-wysiwyg-editor/css/plugins/code_snippet.css">
+    <link rel="stylesheet" href="/bower_components/froala-wysiwyg-editor/css/third_party/spell_checker.css">
+    <link rel="stylesheet" href="/bower_components/froala-wysiwyg-editor/css/plugins/special_characters.css">
+    <link rel="stylesheet" href="/bower_components/froala-wysiwyg-editor/css/plugins/collaborative.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/6.65.7/codemirror.min.css">
+
+    <!-- prismjs package for codeSnippet -->
+    <script type="text/javascript"
+      src="https://cdn.jsdelivr.net/npm/prismjs@1.30.0/components/prism-core.min.js"></script>
+    <script type="text/javascript"
+      src="https://cdn.jsdelivr.net/npm/prismjs@1.30.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.30.0/themes/prism.min.css">
+
+    <!-- Include Froala Editor -->
+    <script src="/bower_components/froala-wysiwyg-editor/js/froala_editor.min.js"></script>
+
+    <script type="text/javascript"
+      src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js"></script>
+    <script type="text/javascript"
+      src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/6.65.7/codemirror.min.js"></script>
+    <script type="text/javascript"
+      src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/6.65.7/mode/xml/xml.min.js"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/2.2.7/purify.min.js"></script>
+    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mammoth@1.11.0/mammoth.browser.js"></script>
+
+    <script type="text/javascript" src="/bower_components/froala-wysiwyg-editor/js/froala_editor.min.js"></script>
+    <script type="text/javascript" src="/bower_components/froala-wysiwyg-editor/js/plugins/ai_assist.min.js"></script>
+    <script type="text/javascript" src="/bower_components/froala-wysiwyg-editor/js/plugins/align.min.js"></script>
+    <script type="text/javascript"
+      src="/bower_components/froala-wysiwyg-editor/js/plugins/char_counter.min.js"></script>
+    <script type="text/javascript"
+      src="/bower_components/froala-wysiwyg-editor/js/plugins/code_beautifier.min.js"></script>
+    <script type="text/javascript" src="/bower_components/froala-wysiwyg-editor/js/plugins/code_view.min.js"></script>
+    <script type="text/javascript" src="/bower_components/froala-wysiwyg-editor/js/plugins/colors.min.js"></script>
+    <script type="text/javascript" src="/bower_components/froala-wysiwyg-editor/js/plugins/draggable.min.js"></script>
+    <script type="text/javascript" src="/bower_components/froala-wysiwyg-editor/js/plugins/emoticons.min.js"></script>
+    <script type="text/javascript" src="/bower_components/froala-wysiwyg-editor/js/plugins/entities.min.js"></script>
+    <script type="text/javascript" src="/bower_components/froala-wysiwyg-editor/js/plugins/file.min.js"></script>
+    <script type="text/javascript" src="/bower_components/froala-wysiwyg-editor/js/plugins/font_size.min.js"></script>
+    <script type="text/javascript" src="/bower_components/froala-wysiwyg-editor/js/plugins/font_family.min.js"></script>
+    <script type="text/javascript" src="/bower_components/froala-wysiwyg-editor/js/plugins/fullscreen.min.js"></script>
+    <script type="text/javascript" src="/bower_components/froala-wysiwyg-editor/js/plugins/image.min.js"></script>
+    <script type="text/javascript"
+      src="/bower_components/froala-wysiwyg-editor/js/plugins/image_manager.min.js"></script>
+    <script type="text/javascript"
+      src="/bower_components/froala-wysiwyg-editor/js/plugins/line_breaker.min.js"></script>
+    <script type="text/javascript"
+      src="/bower_components/froala-wysiwyg-editor/js/plugins/inline_style.min.js"></script>
+    <script type="text/javascript" src="/bower_components/froala-wysiwyg-editor/js/plugins/link.min.js"></script>
+    <script type="text/javascript" src="/bower_components/froala-wysiwyg-editor/js/plugins/lists.min.js"></script>
+    <script type="text/javascript"
+      src="/bower_components/froala-wysiwyg-editor/js/plugins/paragraph_format.min.js"></script>
+    <script type="text/javascript"
+      src="/bower_components/froala-wysiwyg-editor/js/plugins/paragraph_style.min.js"></script>
+    <script type="text/javascript"
+      src="/bower_components/froala-wysiwyg-editor/js/plugins/quick_insert.min.js"></script>
+    <script type="text/javascript" src="/bower_components/froala-wysiwyg-editor/js/plugins/quote.min.js"></script>
+    <script type="text/javascript" src="/bower_components/froala-wysiwyg-editor/js/plugins/table.min.js"></script>
+    <script type="text/javascript" src="/bower_components/froala-wysiwyg-editor/js/plugins/save.min.js"></script>
+    <script type="text/javascript" src="/bower_components/froala-wysiwyg-editor/js/plugins/url.min.js"></script>
+    <script type="text/javascript" src="/bower_components/froala-wysiwyg-editor/js/plugins/video.min.js"></script>
+    <script type="text/javascript" src="/bower_components/froala-wysiwyg-editor/js/plugins/help.min.js"></script>
+    <script type="text/javascript" src="/bower_components/froala-wysiwyg-editor/js/plugins/print.min.js"></script>
+    <script type="text/javascript"
+      src="/bower_components/froala-wysiwyg-editor/js/third_party/spell_checker.min.js"></script>
+    <script type="text/javascript"
+      src="/bower_components/froala-wysiwyg-editor/js/plugins/special_characters.min.js"></script>
+    <script type="text/javascript" src="/bower_components/froala-wysiwyg-editor/js/plugins/word_paste.min.js"></script>
+    <script type="text/javascript"
+      src="/bower_components/froala-wysiwyg-editor/js/plugins/export_to_word.min.js"></script>
+    <script type="text/javascript"
+      src="/bower_components/froala-wysiwyg-editor/js/plugins/import_from_word.min.js"></script>
+    <script type="text/javascript"
+      src="/bower_components/froala-wysiwyg-editor/js/plugins/code_snippet.min.js"></script>
+    <script type="text/javascript"
+      src="/bower_components/froala-wysiwyg-editor/js/plugins/collaborative.min.js"></script>
+
+    <link rel="stylesheet" href="./style.css">
+</head>
+
+<body class="editor-page">
+
+  <header class="editor-header">
+    <div class="header-left">
+      <svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <rect width="32" height="32" rx="8" fill="#0098f7" />
+        <path d="M8 10h16M8 16h10M8 22h13" stroke="#fff" stroke-width="2.5" stroke-linecap="round" />
+      </svg>
+      <span class="app-name">Collaborative Plugin</span>
+      <span class="room-badge" id="room-badge">room</span>
+    </div>
+
+    <div class="user-chip" id="user-chip">
+      <div class="user-avatar" id="user-avatar"></div>
+      <div>
+        <div class="user-name" id="user-name-display"></div>
+        <div class="user-role" id="user-role-display"></div>
+      </div>
+      <a href="./" class="change-user">Change</a>
+    </div>
+  </header>
+
+  <main class="editor-body">
+    <div id="froala-editor"></div>
+  </main>
+
+  <script>
+    (function () {
+      const params = new URLSearchParams(window.location.search);
+      const user = {
+        id: params.get('id') || 'guest-' + Math.random().toString(36).slice(2, 6),
+        name: params.get('name') || 'Guest',
+        role: params.get('role') || 'editor'
+      };
+      const room = params.get('room') || 'demo-room';
+
+      document.getElementById('room-badge').textContent = room;
+      document.getElementById('user-name-display').textContent = user.name;
+      document.getElementById('user-role-display').textContent = user.role;
+
+      const avatar = document.getElementById('user-avatar');
+      avatar.textContent = user.name.charAt(0).toUpperCase();
+      avatar.style.background = '#0098f7';
+
+      document.title = `${user.name} — Collaborative Plugin`;
+
+      if (!params.get('name')) {
+        window.location.href = '/index.html';
+      }
+
+      const backendUrl = window.location.origin;
+      const syncUrl = `${window.location.protocol === 'https:' ? 'wss' : 'ws'}://${window.location.host}`;
+
+      const mode = params.get('mode') || 'realtime';
+      const versionHistory = params.get('versionHistory') === '1';
+      const autoSave = params.get('autoSave') === '1';
+      const autoSaveInterval = parseInt(params.get('autoSaveInterval')) || 300000;
+      const mentionUsersParam = params.get('mentionUsers');
+      const mentionableUsers = mentionUsersParam
+        ? mentionUsersParam.split(',').map(n => ({
+            id: n.trim().toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, ''),
+            name: n.trim()
+          }))
+        : [];
+
+      const collabOptions = {
+        enabled: true,
+        user: { id: user.id, name: user.name, role: user.role },
+        room,
+        backendUrl,
+        ...(mentionableUsers.length ? { mentionableUsers } : {})
+      };
+
+      const editorConfig = { height: 600, collabOptions };
+
+      if (mode === 'realtime') {
+        editorConfig.realTimeConfig = { syncUrl };
+      } else {
+        editorConfig.saveURL = `/collab/${room}/content`;
+        editorConfig.saveInterval = 10000;
+        editorConfig.events = {
+          initialized: function () {
+            const editor = this;
+            fetch(`${backendUrl}/collab/${room}/content`)
+              .then(res => res.ok ? res.json() : null)
+              .then(data => { if (data && data.content) editor.html.set(data.content); })
+              .catch(() => {});
+          }
+        };
+      }
+
+      if (versionHistory) {
+        editorConfig.versionHistoryOptions = {
+          enabled: true,
+          autoSaveEnabled: autoSave,
+          ...(autoSave ? { autoSaveInterval } : {})
+        };
+      }
+
+      new FroalaEditor('#froala-editor', editorConfig);
+
+    })();
+  </script>
+</body>
+
+</html>

--- a/examples/collaborative/editor.html
+++ b/examples/collaborative/editor.html
@@ -123,7 +123,7 @@
         <path d="M8 10h16M8 16h10M8 22h13" stroke="#fff" stroke-width="2.5" stroke-linecap="round" />
       </svg>
       <span class="app-name">Collaborative Plugin</span>
-      <span class="room-badge" id="room-badge">room</span>
+      <span class="room-badge" id="room-badge">docId</span>
     </div>
 
     <div class="user-chip" id="user-chip">
@@ -148,9 +148,9 @@
         name: params.get('name') || 'Guest',
         role: params.get('role') || 'editor'
       };
-      const room = params.get('room') || 'demo-room';
+      const docId = params.get('docId') || 'demo-doc';
 
-      document.getElementById('room-badge').textContent = room;
+      document.getElementById('room-badge').textContent = docId;
       document.getElementById('user-name-display').textContent = user.name;
       document.getElementById('user-role-display').textContent = user.role;
 
@@ -182,9 +182,9 @@
       const collabConfig = {
         enabled: true,
         user: { id: user.id, name: user.name, role: user.role },
-        docId: room,
-        commentsUrl: `${backendUrl}/collab/${room}/comments`,
-        suggestionsUrl: `${backendUrl}/collab/${room}/suggestions`,
+        docId: docId,
+        commentsUrl: `${backendUrl}/collab/${docId}/comments`,
+        suggestionsUrl: `${backendUrl}/collab/${docId}/suggestions`,
         ...(mentionableUsers.length ? { mentionableUsers } : {})
       };
 
@@ -193,12 +193,12 @@
       if (mode === 'realtime') {
         collabConfig.realTime = { syncUrl };
       } else {
-        editorConfig.saveURL = `/collab/${room}/content`;
+        editorConfig.saveURL = `/collab/${docId}/content`;
         editorConfig.saveInterval = 10000;
         editorConfig.events = {
           initialized: function () {
             const editor = this;
-            fetch(`${backendUrl}/collab/${room}/content`)
+            fetch(`${backendUrl}/collab/${docId}/content`)
               .then(res => res.ok ? res.json() : null)
               .then(data => { if (data && data.content) editor.html.set(data.content); })
               .catch(() => {});
@@ -210,7 +210,7 @@
         collabConfig.versionControl = {
           enabled: true,
           autoSaveEnabled: autoSave,
-          url: `${backendUrl}/collab/${room}/versions`,
+          url: `${backendUrl}/collab/${docId}/versions`,
           ...(autoSave ? { autoSaveInterval } : {})
         };
       }

--- a/examples/collaborative/editor.html
+++ b/examples/collaborative/editor.html
@@ -168,7 +168,7 @@
       const syncUrl = `${window.location.protocol === 'https:' ? 'wss' : 'ws'}://${window.location.host}`;
 
       const mode = params.get('mode') || 'realtime';
-      const versionHistory = params.get('versionHistory') === '1';
+      const versionControl = params.get('versionControl') === '1';
       const autoSave = params.get('autoSave') === '1';
       const autoSaveInterval = parseInt(params.get('autoSaveInterval')) || 300000;
       const mentionUsersParam = params.get('mentionUsers');
@@ -206,7 +206,7 @@
         };
       }
 
-      if (versionHistory) {
+      if (versionControl) {
         collabConfig.versionControl = {
           enabled: true,
           autoSaveEnabled: autoSave,

--- a/examples/collaborative/editor.html
+++ b/examples/collaborative/editor.html
@@ -16,7 +16,8 @@
     <link rel="stylesheet" href="/bower_components/froala-wysiwyg-editor/css/froala_editor.min.css" />
     <link rel="stylesheet" href="/bower_components/froala-wysiwyg-editor/css/froala_style.min.css" />
 
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.4.0/css/font-awesome.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.4.0/css/font-awesome.min.css"
+      integrity="sha384-MI32KR77SgI9QAPUs+6R7leEOwtop70UsjEtFEezfKnMjXWx15NENsZpfDgq8m8S" crossorigin="anonymous">
     <link rel="stylesheet" href="/bower_components/froala-wysiwyg-editor/css/froala_editor.css">
     <link rel="stylesheet" href="/bower_components/froala-wysiwyg-editor/css/froala_style.css">
     <link rel="stylesheet" href="/bower_components/froala-wysiwyg-editor/css/plugins/ai_assist.css">

--- a/examples/collaborative/editor.html
+++ b/examples/collaborative/editor.html
@@ -179,18 +179,19 @@
           }))
         : [];
 
-      const collabOptions = {
+      const collabConfig = {
         enabled: true,
         user: { id: user.id, name: user.name, role: user.role },
-        room,
-        backendUrl,
+        docId: room,
+        commentsUrl: `${backendUrl}/collab/${room}/comments`,
+        suggestionsUrl: `${backendUrl}/collab/${room}/suggestions`,
         ...(mentionableUsers.length ? { mentionableUsers } : {})
       };
 
-      const editorConfig = { height: 600, collabOptions };
+      const editorConfig = { height: 600, collabConfig };
 
       if (mode === 'realtime') {
-        editorConfig.realTimeConfig = { syncUrl };
+        collabConfig.realTime = { syncUrl };
       } else {
         editorConfig.saveURL = `/collab/${room}/content`;
         editorConfig.saveInterval = 10000;
@@ -206,9 +207,10 @@
       }
 
       if (versionHistory) {
-        editorConfig.versionHistoryOptions = {
+        collabConfig.versionControl = {
           enabled: true,
           autoSaveEnabled: autoSave,
+          url: `${backendUrl}/collab/${room}/versions`,
           ...(autoSave ? { autoSaveInterval } : {})
         };
       }

--- a/examples/collaborative/editor.html
+++ b/examples/collaborative/editor.html
@@ -47,9 +47,6 @@
       src="https://cdn.jsdelivr.net/npm/prismjs@1.30.0/plugins/autoloader/prism-autoloader.min.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.30.0/themes/prism.min.css">
 
-    <!-- Include Froala Editor -->
-    <script src="/bower_components/froala-wysiwyg-editor/js/froala_editor.min.js"></script>
-
     <script type="text/javascript"
       src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js"></script>
     <script type="text/javascript"
@@ -201,7 +198,7 @@
             fetch(`${backendUrl}/collab/${docId}/content`)
               .then(res => res.ok ? res.json() : null)
               .then(data => { if (data && data.content) editor.html.set(data.content); })
-              .catch(() => {});
+              .catch((err) => { console.error('[collab] Failed to restore content:', err); });
           }
         };
       }

--- a/examples/collaborative/editor.html
+++ b/examples/collaborative/editor.html
@@ -38,23 +38,32 @@
     <link rel="stylesheet" href="/bower_components/froala-wysiwyg-editor/css/third_party/spell_checker.css">
     <link rel="stylesheet" href="/bower_components/froala-wysiwyg-editor/css/plugins/special_characters.css">
     <link rel="stylesheet" href="/bower_components/froala-wysiwyg-editor/css/plugins/collaborative.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/6.65.7/codemirror.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/6.65.7/codemirror.min.css"
+      integrity="sha384-zaeBlB/vwYsDRSlFajnDd7OydJ0cWk+c2OWybl3eSUf6hW2EbhlCsQPqKr3gkznT" crossorigin="anonymous">
 
     <!-- prismjs package for codeSnippet -->
     <script type="text/javascript"
-      src="https://cdn.jsdelivr.net/npm/prismjs@1.30.0/components/prism-core.min.js"></script>
+      src="https://cdn.jsdelivr.net/npm/prismjs@1.30.0/components/prism-core.min.js"
+      integrity="sha384-zLRFO4dwowZvh8kzutOb5AWhH7f39HeJp+N7PtHF1SQtTBnifRx0AtmvTYs3F4YV" crossorigin="anonymous"></script>
     <script type="text/javascript"
-      src="https://cdn.jsdelivr.net/npm/prismjs@1.30.0/plugins/autoloader/prism-autoloader.min.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.30.0/themes/prism.min.css">
+      src="https://cdn.jsdelivr.net/npm/prismjs@1.30.0/plugins/autoloader/prism-autoloader.min.js"
+      integrity="sha384-Uq05+JLko69eOiPr39ta9bh7kld5PKZoU+fF7g0EXTAriEollhZ+DrN8Q/Oi8J2Q" crossorigin="anonymous"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.30.0/themes/prism.min.css"
+      integrity="sha384-rCCjoCPCsizaAAYVoz1Q0CmCTvnctK0JkfCSjx7IIxexTBg+uCKtFYycedUjMyA2" crossorigin="anonymous">
 
     <script type="text/javascript"
-      src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js"></script>
+      src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js"
+      integrity="sha384-Yv5O+t3uE3hunW8uyrbpPW3iw6/5/Y7HitWJBLgqfMoA36NogMmy+8wWZMpn3HWc" crossorigin="anonymous"></script>
     <script type="text/javascript"
-      src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/6.65.7/codemirror.min.js"></script>
+      src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/6.65.7/codemirror.min.js"
+      integrity="sha384-4jtDQkm5WXyXl9gNSgtjNod/6XkUGfxETi+BJ3EuN7ApjJ7/HZoK7PHThKqCkCxp" crossorigin="anonymous"></script>
     <script type="text/javascript"
-      src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/6.65.7/mode/xml/xml.min.js"></script>
-    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/2.2.7/purify.min.js"></script>
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mammoth@1.11.0/mammoth.browser.js"></script>
+      src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/6.65.7/mode/xml/xml.min.js"
+      integrity="sha384-xPpkMo5nDgD98fIcuRVYhxkZV6/9Y4L8s3p0J5c4MxgJkyKJ8BJr+xfRkq7kn6Tw" crossorigin="anonymous"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/2.2.7/purify.min.js"
+      integrity="sha384-cn5CQtD1KW3XEJbmZipeNG2pq0b4WI6PXFhd83xBTcOzB0HubvrHXDkfO3kmM7oV" crossorigin="anonymous"></script>
+    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mammoth@1.11.0/mammoth.browser.js"
+      integrity="sha384-bUIp1lrZr1mMwTLdByoRycie3psHDUiKZeQYICIueCdAsINxuowx/1gDY5SMcpGk" crossorigin="anonymous"></script>
 
     <script type="text/javascript" src="/bower_components/froala-wysiwyg-editor/js/froala_editor.min.js"></script>
     <script type="text/javascript" src="/bower_components/froala-wysiwyg-editor/js/plugins/ai_assist.min.js"></script>
@@ -140,10 +149,12 @@
   <script>
     (function () {
       const params = new URLSearchParams(window.location.search);
+      const VALID_ROLES = ['editor', 'suggester', 'viewer'];
+      const rawRole = params.get('role');
       const user = {
         id: params.get('id') || 'guest-' + Math.random().toString(36).slice(2, 6),
         name: params.get('name') || 'Guest',
-        role: params.get('role') || 'editor'
+        role: VALID_ROLES.includes(rawRole) ? rawRole : 'viewer'
       };
       const docId = params.get('docId') || 'demo-doc';
 

--- a/examples/collaborative/index.html
+++ b/examples/collaborative/index.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Collaborative Plugin — Join Session</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+
+<body class="login-page">
+
+  <div class="login-card">
+    <div class="logo">
+      <svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <rect width="32" height="32" rx="8" fill="#0098f7" />
+        <path d="M8 10h16M8 16h10M8 22h13" stroke="#fff" stroke-width="2.5" stroke-linecap="round" />
+      </svg>
+      <span>Collaborative Plugin</span>
+    </div>
+
+    <div class="step-indicator">
+      <span class="step-dot active"></span>
+      <span class="step-line"><span class="step-line-fill" id="step-line-fill"></span></span>
+      <span class="step-dot" id="dot-2"></span>
+    </div>
+
+    <form id="user-form" novalidate>
+
+      <!-- ── Step 1: User details ── -->
+      <div id="step-1">
+        <h1>Join the editor</h1>
+        <p class="subtitle">Enter your details to start collaborating.</p>
+
+        <div class="form-group">
+          <label for="input-name">Your name</label>
+          <input type="text" id="input-name" name="name" placeholder="e.g. Jane Doe" required autocomplete="off">
+        </div>
+
+        <div class="form-group">
+          <label>Your role</label>
+          <div class="role-options">
+            <div class="role-option">
+              <input type="radio" name="role" id="role-editor" value="editor" checked>
+              <label for="role-editor">
+                <span class="role-icon">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 14 14" fill="none">
+                    <path
+                      d="M1.5 12H2.56875L9.9 4.66875L8.83125 3.6L1.5 10.9313V12ZM0.75 13.5C0.5375 13.5 0.359375 13.4281 0.215625 13.2844C0.071875 13.1406 0 12.9625 0 12.75V10.9313C0 10.7313 0.0375 10.5406 0.1125 10.3594C0.1875 10.1781 0.29375 10.0188 0.43125 9.88125L9.9 0.43125C10.05 0.29375 10.2156 0.1875 10.3969 0.1125C10.5781 0.0375 10.7688 0 10.9688 0C11.1688 0 11.3625 0.0375 11.55 0.1125C11.7375 0.1875 11.9 0.3 12.0375 0.45L13.0688 1.5C13.2188 1.6375 13.3281 1.8 13.3969 1.9875C13.4656 2.175 13.5 2.3625 13.5 2.55C13.5 2.75 13.4656 2.94063 13.3969 3.12188C13.3281 3.30313 13.2188 3.46875 13.0688 3.61875L3.61875 13.0688C3.48125 13.2063 3.32188 13.3125 3.14063 13.3875C2.95938 13.4625 2.76875 13.5 2.56875 13.5H0.75ZM9.35625 4.14375L8.83125 3.6L9.9 4.66875L9.35625 4.14375Z"
+                      fill="#999999" />
+                  </svg>
+                </span>
+                Editor
+              </label>
+            </div>
+            <div class="role-option">
+              <input type="radio" name="role" id="role-suggester" value="suggester">
+              <label for="role-suggester">
+                <span class="role-icon">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18" fill="none">
+                    <path
+                      d="M5.25 10.5H6.46875C6.56875 10.5 6.66563 10.4812 6.75938 10.4437C6.85313 10.4062 6.9375 10.35 7.0125 10.275L10.5375 6.75C10.65 6.6375 10.7344 6.50937 10.7906 6.36562C10.8469 6.22187 10.875 6.08125 10.875 5.94375C10.875 5.80625 10.8438 5.67187 10.7812 5.54062C10.7188 5.40937 10.6375 5.2875 10.5375 5.175L9.8625 4.4625C9.75 4.35 9.625 4.26562 9.4875 4.20937C9.35 4.15312 9.20625 4.125 9.05625 4.125C8.91875 4.125 8.77813 4.15312 8.63438 4.20937C8.49063 4.26562 8.3625 4.35 8.25 4.4625L4.725 7.9875C4.65 8.0625 4.59375 8.14687 4.55625 8.24062C4.51875 8.33437 4.5 8.43125 4.5 8.53125V9.75C4.5 9.9625 4.57188 10.1406 4.71563 10.2844C4.85938 10.4281 5.0375 10.5 5.25 10.5ZM5.625 9.375V8.6625L7.51875 6.76875L7.89375 7.10625L8.23125 7.48125L6.3375 9.375H5.625ZM7.89375 7.10625L8.23125 7.48125L7.51875 6.76875L7.89375 7.10625ZM8.38125 10.5H12.75C12.9625 10.5 13.1406 10.4281 13.2844 10.2844C13.4281 10.1406 13.5 9.9625 13.5 9.75C13.5 9.5375 13.4281 9.35937 13.2844 9.21562C13.1406 9.07187 12.9625 9 12.75 9H9.88125L8.38125 10.5ZM4.5 13.5L2.775 15.225C2.5375 15.4625 2.26563 15.5156 1.95938 15.3844C1.65312 15.2531 1.5 15.0187 1.5 14.6812V3C1.5 2.5875 1.64687 2.23437 1.94063 1.94062C2.23438 1.64687 2.5875 1.5 3 1.5H15C15.4125 1.5 15.7656 1.64687 16.0594 1.94062C16.3531 2.23437 16.5 2.5875 16.5 3V12C16.5 12.4125 16.3531 12.7656 16.0594 13.0594C15.7656 13.3531 15.4125 13.5 15 13.5H4.5ZM3.8625 12H15V3H3V12.8437L3.8625 12Z"
+                      fill="#999999" />
+                  </svg>
+                </span>
+                Suggester
+              </label>
+            </div>
+            <div class="role-option">
+              <input type="radio" name="role" id="role-viewer" value="viewer">
+              <label for="role-viewer">
+                <span class="role-icon">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18" fill="none">
+                    <path
+                      d="M11.3875 11.0156C12.0437 10.3594 12.3719 9.5625 12.3719 8.625C12.3719 7.6875 12.0437 6.89063 11.3875 6.23438C10.7312 5.57812 9.93437 5.25 8.99687 5.25C8.05937 5.25 7.2625 5.57812 6.60625 6.23438C5.95 6.89063 5.62187 7.6875 5.62187 8.625C5.62187 9.5625 5.95 10.3594 6.60625 11.0156C7.2625 11.6719 8.05937 12 8.99687 12C9.93437 12 10.7312 11.6719 11.3875 11.0156ZM7.5625 10.0594C7.16875 9.66563 6.97187 9.1875 6.97187 8.625C6.97187 8.0625 7.16875 7.58438 7.5625 7.19063C7.95625 6.79688 8.43437 6.6 8.99687 6.6C9.55937 6.6 10.0375 6.79688 10.4312 7.19063C10.825 7.58438 11.0219 8.0625 11.0219 8.625C11.0219 9.1875 10.825 9.66563 10.4312 10.0594C10.0375 10.4531 9.55937 10.65 8.99687 10.65C8.43437 10.65 7.95625 10.4531 7.5625 10.0594ZM4.4125 12.9C3.03125 12 1.94062 10.8125 1.14062 9.3375C1.07812 9.225 1.03125 9.10938 1 8.99063C0.96875 8.87188 0.953125 8.75 0.953125 8.625C0.953125 8.5 0.96875 8.37813 1 8.25938C1.03125 8.14062 1.07812 8.025 1.14062 7.9125C1.94062 6.4375 3.03125 5.25 4.4125 4.35C5.79375 3.45 7.32187 3 8.99687 3C10.6719 3 12.2 3.45 13.5812 4.35C14.9625 5.25 16.0531 6.4375 16.8531 7.9125C16.9156 8.025 16.9625 8.14062 16.9937 8.25938C17.025 8.37813 17.0406 8.5 17.0406 8.625C17.0406 8.75 17.025 8.87188 16.9937 8.99063C16.9625 9.10938 16.9156 9.225 16.8531 9.3375C16.0531 10.8125 14.9625 12 13.5812 12.9C12.2 13.8 10.6719 14.25 8.99687 14.25C7.32187 14.25 5.79375 13.8 4.4125 12.9ZM12.8875 11.6344C14.0687 10.8906 14.9719 9.8875 15.5969 8.625C14.9719 7.3625 14.0687 6.35938 12.8875 5.61563C11.7062 4.87188 10.4094 4.5 8.99687 4.5C7.58437 4.5 6.2875 4.87188 5.10625 5.61563C3.925 6.35938 3.02187 7.3625 2.39687 8.625C3.02187 9.8875 3.925 10.8906 5.10625 11.6344C6.2875 12.3781 7.58437 12.75 8.99687 12.75C10.4094 12.75 11.7062 12.3781 12.8875 11.6344Z"
+                      fill="#999999" />
+                  </svg>
+                </span>
+                Viewer
+              </label>
+            </div>
+          </div>
+        </div>
+
+        <div class="form-group">
+          <label for="input-room">Room name</label>
+          <input type="text" id="input-room" name="room" value="demo-room" placeholder="demo-room">
+        </div>
+
+        <button type="button" id="btn-next" class="btn-primary">Next →</button>
+      </div>
+
+      <!-- ── Step 2: Editor options ── -->
+      <div id="step-2" hidden>
+        <h1>Editor options</h1>
+        <p class="subtitle">Configure your collaboration session.</p>
+
+        <div class="form-group">
+          <label>Collaboration mode</label>
+          <div class="role-options">
+            <div class="role-option">
+              <input type="radio" name="mode" id="mode-realtime" value="realtime" checked>
+              <label for="mode-realtime">Real-time</label>
+            </div>
+            <div class="role-option">
+              <input type="radio" name="mode" id="mode-async" value="async">
+              <label for="mode-async">Asynchronous</label>
+            </div>
+          </div>
+        </div>
+
+        <div class="option-group">
+          <div class="form-group toggle-row">
+            <span class="toggle-label">Version history</span>
+            <label class="toggle-switch">
+              <input type="checkbox" id="toggle-version-history">
+              <span class="toggle-track"></span>
+            </label>
+          </div>
+          <div class="form-group toggle-row">
+            <span class="toggle-label">Auto-save</span>
+            <label class="toggle-switch">
+              <input type="checkbox" id="toggle-autosave" disabled>
+              <span class="toggle-track"></span>
+            </label>
+          </div>
+          <div class="form-group" id="group-autosave-interval" hidden>
+            <label for="input-autosave-interval">Auto-save interval (ms)</label>
+            <input type="number" id="input-autosave-interval" value="300000" min="5000">
+          </div>
+        </div>
+
+        <div class="form-group">
+          <label>Mentionable users</label>
+          <div class="mention-add-row">
+            <input type="text" id="input-mention-name" placeholder="e.g. Jane Doe" autocomplete="off">
+            <button type="button" id="btn-add-mention" class="btn-add">Add</button>
+          </div>
+          <ul id="mention-list" class="mention-list"></ul>
+        </div>
+
+        <div class="step-nav">
+          <button type="button" id="btn-back" class="btn-secondary">← Back</button>
+          <button type="submit" class="btn-primary">Start editing →</button>
+        </div>
+      </div>
+
+    </form>
+  </div>
+
+  <script type="module" src="./main.js"></script>
+  <script>
+    const step1 = document.getElementById('step-1');
+    const step2 = document.getElementById('step-2');
+    const dot2 = document.getElementById('dot-2');
+    const lineFill = document.getElementById('step-line-fill');
+
+    document.getElementById('btn-next').addEventListener('click', function () {
+      const name = document.getElementById('input-name').value.trim();
+      if (!name) { document.getElementById('input-name').focus(); return; }
+      step1.hidden = true;
+      step2.hidden = false;
+      dot2.classList.add('active');
+      lineFill.style.width = '100%';
+    });
+
+    document.getElementById('btn-back').addEventListener('click', function () {
+      step2.hidden = true;
+      step1.hidden = false;
+      dot2.classList.remove('active');
+      lineFill.style.width = '0%';
+    });
+
+    document.getElementById('toggle-version-history').addEventListener('change', function () {
+      const autoSave = document.getElementById('toggle-autosave');
+      autoSave.disabled = !this.checked;
+      if (!this.checked) {
+        autoSave.checked = false;
+        document.getElementById('group-autosave-interval').hidden = true;
+      }
+    });
+
+    document.getElementById('toggle-autosave').addEventListener('change', function () {
+      document.getElementById('group-autosave-interval').hidden = !this.checked;
+    });
+
+    function addMentionUser(name) {
+      const li = document.createElement('li');
+      li.className = 'mention-item';
+      li.dataset.name = name;
+      li.innerHTML = `<span>${name}</span><button type="button" class="btn-remove-mention" aria-label="Remove">&times;</button>`;
+      li.querySelector('.btn-remove-mention').addEventListener('click', () => li.remove());
+      document.getElementById('mention-list').appendChild(li);
+    }
+
+    document.getElementById('btn-add-mention').addEventListener('click', function () {
+      const input = document.getElementById('input-mention-name');
+      const name = input.value.trim();
+      if (!name) return;
+      addMentionUser(name);
+      input.value = '';
+      input.focus();
+    });
+
+    document.getElementById('input-mention-name').addEventListener('keydown', function (e) {
+      if (e.key === 'Enter') { e.preventDefault(); document.getElementById('btn-add-mention').click(); }
+    });
+  </script>
+
+</body>
+
+</html>

--- a/examples/collaborative/index.html
+++ b/examples/collaborative/index.html
@@ -83,8 +83,8 @@
         </div>
 
         <div class="form-group">
-          <label for="input-room">Room name</label>
-          <input type="text" id="input-room" name="room" value="demo-room" placeholder="demo-room">
+          <label for="input-docId">Document ID</label>
+          <input type="text" id="input-docId" name="docId" value="demo-doc" placeholder="demo-doc">
         </div>
 
         <button type="button" id="btn-next" class="btn-primary">Next →</button>

--- a/examples/collaborative/index.html
+++ b/examples/collaborative/index.html
@@ -111,9 +111,9 @@
 
         <div class="option-group">
           <div class="form-group toggle-row">
-            <span class="toggle-label">Version history</span>
+            <span class="toggle-label">Version control</span>
             <label class="toggle-switch">
-              <input type="checkbox" id="toggle-version-history">
+              <input type="checkbox" id="toggle-version-control">
               <span class="toggle-track"></span>
             </label>
           </div>
@@ -171,7 +171,7 @@
       lineFill.style.width = '0%';
     });
 
-    document.getElementById('toggle-version-history').addEventListener('change', function () {
+    document.getElementById('toggle-version-control').addEventListener('change', function () {
       const autoSave = document.getElementById('toggle-autosave');
       autoSave.disabled = !this.checked;
       if (!this.checked) {

--- a/examples/collaborative/main.js
+++ b/examples/collaborative/main.js
@@ -1,0 +1,31 @@
+function generateId(name) {
+  const slug = name.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
+  return slug + '-' + Math.random().toString(36).slice(2, 6);
+}
+
+document.getElementById('user-form').addEventListener('submit', (e) => {
+  e.preventDefault();
+
+  const name = document.getElementById('input-name').value.trim();
+  if (!name) {
+    document.getElementById('input-name').focus();
+    return;
+  }
+
+  const role = document.querySelector('input[name="role"]:checked').value;
+  const room = document.getElementById('input-room').value.trim() || 'demo-room';
+  const id = generateId(name);
+  const mode = document.querySelector('input[name="mode"]:checked').value;
+  const versionHistory = document.getElementById('toggle-version-history').checked;
+  const autoSave = versionHistory && document.getElementById('toggle-autosave').checked;
+  const autoSaveInterval = document.getElementById('input-autosave-interval').value;
+  const mentionUsers = [...document.querySelectorAll('#mention-list .mention-item')]
+    .map(li => li.dataset.name).join(',');
+
+  const params = new URLSearchParams({ id, name, role, room, mode });
+  if (versionHistory) params.set('versionHistory', '1');
+  if (autoSave) params.set('autoSave', '1');
+  if (autoSave && autoSaveInterval) params.set('autoSaveInterval', autoSaveInterval);
+  if (mentionUsers) params.set('mentionUsers', mentionUsers);
+  window.location.href = `/collaborative/editor.html?${params}`;
+});

--- a/examples/collaborative/main.js
+++ b/examples/collaborative/main.js
@@ -16,14 +16,14 @@ document.getElementById('user-form').addEventListener('submit', (e) => {
   const docId = document.getElementById('input-docId').value.trim() || 'demo-doc';
   const id = generateId(name);
   const mode = document.querySelector('input[name="mode"]:checked').value;
-  const versionHistory = document.getElementById('toggle-version-history').checked;
-  const autoSave = versionHistory && document.getElementById('toggle-autosave').checked;
+  const versionControl = document.getElementById('toggle-version-control').checked;
+  const autoSave = versionControl && document.getElementById('toggle-autosave').checked;
   const autoSaveInterval = document.getElementById('input-autosave-interval').value;
   const mentionUsers = [...document.querySelectorAll('#mention-list .mention-item')]
     .map(li => li.dataset.name).join(',');
 
   const params = new URLSearchParams({ id, name, role, docId, mode });
-  if (versionHistory) params.set('versionHistory', '1');
+  if (versionControl) params.set('versionControl', '1');
   if (autoSave) params.set('autoSave', '1');
   if (autoSave && autoSaveInterval) params.set('autoSaveInterval', autoSaveInterval);
   if (mentionUsers) params.set('mentionUsers', mentionUsers);

--- a/examples/collaborative/main.js
+++ b/examples/collaborative/main.js
@@ -13,7 +13,7 @@ document.getElementById('user-form').addEventListener('submit', (e) => {
   }
 
   const role = document.querySelector('input[name="role"]:checked').value;
-  const room = document.getElementById('input-room').value.trim() || 'demo-room';
+  const docId = document.getElementById('input-docId').value.trim() || 'demo-doc';
   const id = generateId(name);
   const mode = document.querySelector('input[name="mode"]:checked').value;
   const versionHistory = document.getElementById('toggle-version-history').checked;
@@ -22,7 +22,7 @@ document.getElementById('user-form').addEventListener('submit', (e) => {
   const mentionUsers = [...document.querySelectorAll('#mention-list .mention-item')]
     .map(li => li.dataset.name).join(',');
 
-  const params = new URLSearchParams({ id, name, role, room, mode });
+  const params = new URLSearchParams({ id, name, role, docId, mode });
   if (versionHistory) params.set('versionHistory', '1');
   if (autoSave) params.set('autoSave', '1');
   if (autoSave && autoSaveInterval) params.set('autoSaveInterval', autoSaveInterval);

--- a/examples/collaborative/style.css
+++ b/examples/collaborative/style.css
@@ -1,0 +1,492 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  background: #f5f6f8;
+  color: #1a1a2e;
+  min-height: 100vh;
+}
+
+/* ── Screen 1: User form ── */
+
+.login-page {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  padding: 24px;
+}
+
+.login-card {
+  background: #fff;
+  border-radius: 16px;
+  padding: 48px 40px;
+  width: 100%;
+  max-width: 440px;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.08);
+}
+
+.login-card .logo {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 32px;
+}
+
+.login-card .logo svg {
+  width: 32px;
+  height: 32px;
+  flex-shrink: 0;
+}
+
+.login-card .logo span {
+  font-size: 20px;
+  font-weight: 700;
+  color: #0098f7;
+  letter-spacing: -0.3px;
+}
+
+.login-card h1 {
+  font-size: 24px;
+  font-weight: 700;
+  margin-bottom: 6px;
+  color: #1a1a2e;
+}
+
+.login-card p.subtitle {
+  font-size: 14px;
+  color: #6b7280;
+  margin-bottom: 32px;
+}
+
+.form-group {
+  margin-bottom: 20px;
+}
+
+.form-group label {
+  display: block;
+  font-size: 13px;
+  font-weight: 600;
+  color: #374151;
+  margin-bottom: 6px;
+}
+
+.form-group input[type="text"],
+.form-group input[type="number"],
+.form-group select {
+  width: 100%;
+  padding: 10px 14px;
+  border: 1.5px solid #e5e7eb;
+  border-radius: 8px;
+  font-size: 14px;
+  color: #1a1a2e;
+  background: #fff;
+  transition: border-color 0.15s;
+  outline: none;
+}
+
+.form-group input[type="text"]:focus,
+.form-group input[type="number"]:focus,
+.form-group select:focus {
+  border-color: #0098f7;
+  box-shadow: 0 0 0 3px rgba(0, 152, 247, 0.1);
+}
+
+/* Grouped option card */
+
+.option-group {
+  border: 1.5px solid #e5e7eb;
+  border-radius: 8px;
+  margin-bottom: 20px;
+  overflow: hidden;
+}
+
+.option-group .form-group {
+  padding: 11px 14px;
+  margin-bottom: 0;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.option-group .form-group:last-child {
+  border-bottom: none;
+}
+
+/* Mention add/delete UI */
+
+.mention-add-row {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.mention-add-row input[type="text"] {
+  flex: 1;
+  padding: 10px 14px;
+  border: 1.5px solid #e5e7eb;
+  border-radius: 8px;
+  font-size: 14px;
+  color: #1a1a2e;
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.mention-add-row input[type="text"]:focus {
+  border-color: #0098f7;
+  box-shadow: 0 0 0 3px rgba(0, 152, 247, 0.1);
+}
+
+.btn-add {
+  padding: 10px 16px;
+  background: #0098f7;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s;
+}
+
+.btn-add:hover {
+  background: #007ac1;
+}
+
+.mention-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  max-height: 120px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+.mention-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 7px 12px;
+  background: #f0f9ff;
+  border: 1px solid #bae6fd;
+  border-radius: 6px;
+  font-size: 13px;
+  color: #0369a1;
+}
+
+.btn-remove-mention {
+  background: none;
+  border: none;
+  color: #9ca3af;
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 2px;
+  transition: color 0.15s;
+}
+
+.btn-remove-mention:hover {
+  color: #ef4444;
+}
+
+/* Toggle rows */
+
+.toggle-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.toggle-label {
+  font-size: 13px;
+  font-weight: 600;
+  color: #374151;
+}
+
+.toggle-switch {
+  position: relative;
+  display: inline-block;
+  width: 40px;
+  height: 22px;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.toggle-switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.toggle-track {
+  position: absolute;
+  inset: 0;
+  background: #e5e7eb;
+  border-radius: 22px;
+  transition: background 0.2s;
+}
+
+.toggle-track::after {
+  content: '';
+  position: absolute;
+  left: 3px;
+  top: 3px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #fff;
+  transition: transform 0.2s;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.15);
+}
+
+.toggle-switch input:checked + .toggle-track {
+  background: #0098f7;
+}
+
+.toggle-switch input:checked + .toggle-track::after {
+  transform: translateX(18px);
+}
+
+.toggle-switch input:disabled + .toggle-track {
+  background: #e5e7eb;
+  cursor: not-allowed;
+}
+
+.toggle-switch input:disabled + .toggle-track::after {
+  background: #d1d5db;
+}
+
+.toggle-switch:has(input:disabled) {
+  cursor: not-allowed;
+}
+
+/* Role badges */
+
+.role-options {
+  display: flex;
+  gap: 8px;
+}
+
+.role-option {
+  flex: 1;
+}
+
+.role-option input[type="radio"] {
+  display: none;
+}
+
+.role-option label {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 10px 8px;
+  border: 1.5px solid #e5e7eb;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 600;
+  color: #6b7280;
+  transition: all 0.15s;
+  text-align: center;
+}
+
+.role-option input[type="radio"]:checked + label {
+  border-color: #0098f7;
+  background: #f0f9ff;
+  color: #0098f7;
+}
+
+.role-option label .role-icon {
+  font-size: 18px;
+}
+
+.btn-primary {
+  display: block;
+  width: 100%;
+  padding: 13px;
+  background: #0098f7;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  font-size: 15px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s;
+  margin-top: 8px;
+}
+
+.btn-primary:hover {
+  background: #007ac1;
+}
+
+.btn-secondary {
+  display: block;
+  padding: 13px 20px;
+  background: #fff;
+  color: #374151;
+  border: 1.5px solid #e5e7eb;
+  border-radius: 8px;
+  font-size: 15px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s;
+}
+
+.btn-secondary:hover {
+  border-color: #9ca3af;
+  color: #1a1a2e;
+}
+
+.step-nav {
+  display: flex;
+  gap: 10px;
+  margin-top: 8px;
+}
+
+.step-nav .btn-primary {
+  flex: 1;
+  margin-top: 0;
+}
+
+/* Step indicator */
+
+.step-indicator {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  margin-bottom: 28px;
+}
+
+.step-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #e5e7eb;
+  flex-shrink: 0;
+  transition: background 0.2s;
+}
+
+.step-dot.active {
+  background: #0098f7;
+}
+
+.step-line {
+  flex: 1;
+  height: 2px;
+  background: #e5e7eb;
+  margin: 0 6px;
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.step-line-fill {
+  display: block;
+  height: 100%;
+  width: 0%;
+  background: #0098f7;
+  border-radius: 2px;
+  transition: width 0.25s ease;
+}
+
+/* ── Screen 2: Editor page ── */
+
+.editor-page {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.editor-header {
+  background: #fff;
+  border-bottom: 1px solid #e5e7eb;
+  padding: 12px 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.editor-header .header-left {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.editor-header .header-left svg {
+  width: 24px;
+  height: 24px;
+}
+
+.editor-header .header-left .app-name {
+  font-size: 16px;
+  font-weight: 700;
+  color: #0098f7;
+}
+
+.editor-header .room-badge {
+  font-size: 12px;
+  color: #6b7280;
+  background: #f3f4f6;
+  padding: 3px 10px;
+  border-radius: 20px;
+}
+
+.user-chip {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px 6px 6px;
+  border-radius: 24px;
+  background: #f9fafb;
+  border: 1px solid #e5e7eb;
+}
+
+.user-avatar {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  font-weight: 700;
+  color: #fff;
+  flex-shrink: 0;
+}
+
+.user-chip .user-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: #374151;
+}
+
+.user-chip .user-role {
+  font-size: 11px;
+  color: #9ca3af;
+  text-transform: capitalize;
+}
+
+.user-chip .change-user {
+  font-size: 11px;
+  color: #0098f7;
+  text-decoration: none;
+  margin-left: 4px;
+}
+
+.editor-body {
+  flex: 1;
+  padding: 32px 24px;
+  width: 100%;
+  margin: 0 auto;
+}
+
+#froala-editor {
+  background: #fff;
+  border-radius: 10px;
+  overflow: hidden;
+}

--- a/examples/index.html
+++ b/examples/index.html
@@ -328,6 +328,11 @@
     })();
   </script>
 
+   <div class="sample">
+    <h2>Sample 5: Collaborative Editing</h2>
+    <a href="./collaborative/" target="_blank">Collaborative editor</a>
+  </div>
+
 </body>
 
 </html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -328,7 +328,7 @@
     })();
   </script>
 
-   <div class="sample">
+  <div class="sample">
     <h2>Sample 5: Collaborative Editing</h2>
     <a href="./collaborative/" target="_blank">Collaborative editor</a>
   </div>

--- a/examples/server.js
+++ b/examples/server.js
@@ -1,3 +1,4 @@
+var http = require('http');
 var express = require('express');
 var app = express();
 var bodyParser = require('body-parser')
@@ -5,10 +6,35 @@ var path = require('path');
 var fs = require('fs');
 var gm = require('gm').subClass({imageMagick: true});
 var FroalaEditor = require('../lib/froalaEditor.js');
+var Collaborative = FroalaEditor.Collaborative;
+var CollabPersistence = FroalaEditor.CollabPersistence;
+var VersionHistory = FroalaEditor.VersionHistory;
+var AsyncSave = FroalaEditor.AsyncSave;
+
+// Permissive CORS for the dev environment so the editor's webpack dev server
+// (port 8001) can hit the SDK's REST endpoints (port 3000).
+app.use(function (req, res, next) {
+  res.header('Access-Control-Allow-Origin', '*');
+  res.header('Access-Control-Allow-Methods', 'GET,POST,PATCH,DELETE,OPTIONS');
+  res.header('Access-Control-Allow-Headers', 'Content-Type');
+  if (req.method === 'OPTIONS') return res.sendStatus(204);
+  next();
+});
 
 app.use(express.static(__dirname + '/'));
 app.use('/bower_components',  express.static(path.join(__dirname, '../bower_components')));
+app.use(express.json());
 app.use(bodyParser.urlencoded({ extended: false }));
+
+// Attach suggestion + comment persistence routes.
+CollabPersistence.attachRoutes(app, { dbPath: path.join(__dirname, '..', 'collab.db') });
+
+// Attach version history routes (same SQLite file).
+VersionHistory.attachRoutes(app, { dbPath: path.join(__dirname, '..', 'collab.db') });
+
+// Attach async-save routes — persists the latest editor content per room
+// when the editor runs in async mode (no realTimeConfig.syncUrl).
+AsyncSave.attachRoutes(app, { dbPath: path.join(__dirname, '..', 'collab.db') });
 
 app.get('/', function(req, res) {
   res.sendFile(__dirname + '/index.html');
@@ -194,6 +220,16 @@ if (!fs.existsSync(filesDir)){
     fs.mkdirSync(filesDir);
 }
 
-app.listen(3000, function () {
-  console.log('Example app listening on port 3000!');
+// Health endpoint — reports live room/client counts from the relay.
+app.get('/health', function (req, res) {
+  res.json(Collaborative.getStats());
+});
+
+// Wrap Express in a plain HTTP server so the WebSocket relay can share the port.
+// Clients connect to:  ws://localhost:3000/<roomName>
+var server = http.createServer(app);
+Collaborative.attachToServer(server);
+
+server.listen(3000, '0.0.0.0', function () {
+  console.log('Example app + collaborative relay listening on port 3000');
 });

--- a/examples/server.js
+++ b/examples/server.js
@@ -8,7 +8,7 @@ var gm = require('gm').subClass({imageMagick: true});
 var FroalaEditor = require('../lib/froalaEditor.js');
 var Collaborative = FroalaEditor.Collaborative;
 var CollabPersistence = FroalaEditor.CollabPersistence;
-var VersionHistory = FroalaEditor.VersionHistory;
+var VersionControl = FroalaEditor.VersionControl;
 var AsyncSave = FroalaEditor.AsyncSave;
 
 // Permissive CORS for the dev environment so the editor's webpack dev server
@@ -29,8 +29,8 @@ app.use(bodyParser.urlencoded({ extended: false }));
 // Attach suggestion + comment persistence routes.
 CollabPersistence.attachRoutes(app, { dbPath: path.join(__dirname, '..', 'collab.db') });
 
-// Attach version history routes (same SQLite file).
-VersionHistory.attachRoutes(app, { dbPath: path.join(__dirname, '..', 'collab.db') });
+// Attach version control routes (same SQLite file).
+VersionControl.attachRoutes(app, { dbPath: path.join(__dirname, '..', 'collab.db') });
 
 // Attach async-save routes — persists the latest editor content per room
 // when the editor runs in async mode (no realTimeConfig.syncUrl).
@@ -226,7 +226,7 @@ app.get('/health', function (req, res) {
 });
 
 // Wrap Express in a plain HTTP server so the WebSocket relay can share the port.
-// Clients connect to:  ws://localhost:3000/<roomName>
+// Clients connect to:  ws://localhost:3000/<docId>
 var server = http.createServer(app);
 Collaborative.attachToServer(server);
 

--- a/examples/server.js
+++ b/examples/server.js
@@ -13,6 +13,8 @@ var AsyncSave = FroalaEditor.AsyncSave;
 
 // Permissive CORS for the dev environment so the editor's webpack dev server
 // (port 8001) can hit the SDK's REST endpoints (port 3000).
+// eslint-disable-next-line no-console
+console.warn('[collab] WARNING: CORS is open (*) and routes have no authentication. Do not use this configuration in production.');
 app.use(function (req, res, next) {
   res.header('Access-Control-Allow-Origin', '*');
   res.header('Access-Control-Allow-Methods', 'GET,POST,PATCH,DELETE,OPTIONS');

--- a/examples/server.js
+++ b/examples/server.js
@@ -15,7 +15,7 @@ var AsyncSave = FroalaEditor.AsyncSave;
 // (port 8001) can hit the SDK's REST endpoints (port 3000).
 // eslint-disable-next-line no-console
 console.warn('[collab] WARNING: CORS is open (*) and routes have no authentication. Do not use this configuration in production.');
-app.use(function (req, res, next) {
+app.use('/collab', function (req, res, next) {
   res.header('Access-Control-Allow-Origin', '*');
   res.header('Access-Control-Allow-Methods', 'GET,POST,PATCH,DELETE,OPTIONS');
   res.header('Access-Control-Allow-Headers', 'Content-Type');

--- a/lib/async_save.js
+++ b/lib/async_save.js
@@ -25,6 +25,8 @@ const { getDb, ok, bad, generateId } = require('./collab_db');
 function attachRoutes(app, options) {
   options = options || {};
   const db = getDb(options.dbPath);
+  const auth = options.authMiddleware || function(req, res, next) { next(); };
+  app.use('/collab', auth);
 
   db.exec(`
     CREATE TABLE IF NOT EXISTS async_content (
@@ -50,11 +52,7 @@ function attachRoutes(app, options) {
     const savedAt = Date.now();
 
     try {
-      const existing = db
-        .prepare('SELECT id FROM async_content WHERE doc_id = ?')
-        .get(docId);
-
-      const id = (existing && existing.id) || generateId('ac');
+      const id = generateId('ac');
 
       db.prepare(`
         INSERT INTO async_content (id, doc_id, content, author_id, author_name, saved_at)
@@ -75,7 +73,9 @@ function attachRoutes(app, options) {
 
       ok(res, { doc_id: docId, saved_at: savedAt });
     } catch (err) {
-      bad(res, 500, err.message);
+      // eslint-disable-next-line no-console
+      console.error('[collab] db error:', err);
+      bad(res, 500, 'internal server error');
     }
   });
 
@@ -90,7 +90,9 @@ function attachRoutes(app, options) {
       if (!row) return bad(res, 404, 'no content saved for this document');
       ok(res, row);
     } catch (err) {
-      bad(res, 500, err.message);
+      // eslint-disable-next-line no-console
+      console.error('[collab] db error:', err);
+      bad(res, 500, 'internal server error');
     }
   });
 }

--- a/lib/async_save.js
+++ b/lib/async_save.js
@@ -2,14 +2,14 @@
 
 // ─── Async editor content persistence ────────────────────────────────────────
 //
-// REST endpoints backed by SQLite for storing the latest editor HTML per room.
+// REST endpoints backed by SQLite for storing the latest editor HTML per document.
 // Called by the Froala save plugin (POST with body key "body") when the editor
 // runs in async/offline mode — i.e. when realTimeConfig.syncUrl is not set.
 //
 // Table (auto-created on first call to `attachRoutes`):
-//   async_content(id, room, content, author_id, author_name, saved_at)
+//   async_content(id, doc_id, content, author_id, author_name, saved_at)
 //
-// Each room has exactly one row — a POST always upserts the current content.
+// Each document has exactly one row — a POST always upserts the current content.
 
 let _db = null;
 
@@ -32,14 +32,14 @@ function _getDb(dbPath) {
   _db.exec(`
     CREATE TABLE IF NOT EXISTS async_content (
       id TEXT PRIMARY KEY,
-      room TEXT NOT NULL UNIQUE,
+      doc_id TEXT NOT NULL UNIQUE,
       content TEXT NOT NULL,
       author_id TEXT,
       author_name TEXT,
       saved_at INTEGER NOT NULL
     );
 
-    CREATE INDEX IF NOT EXISTS idx_async_content_room ON async_content(room);
+    CREATE INDEX IF NOT EXISTS idx_async_content_doc_id ON async_content(doc_id);
   `);
 
   return _db;
@@ -77,54 +77,54 @@ function attachRoutes(app, options) {
   options = options || {};
   const db = _getDb(options.dbPath);
 
-  // Save (upsert) the current editor content for a room.
+  // Save (upsert) the current editor content for a document.
   // Called by the Froala save plugin — body key is "body" (saveParam default).
-  app.post('/collab/:room/content', (req, res) => {
+  app.post('/collab/:docId/content', (req, res) => {
     const body = req.body || {};
     const content = body.body;
     if (content == null) return _bad(res, 400, '"body" field is required');
 
-    const room = req.params.room;
+    const docId = req.params.docId;
     const savedAt = Date.now();
 
     try {
       const existing = db
-        .prepare('SELECT id FROM async_content WHERE room = ?')
-        .get(room);
+        .prepare('SELECT id FROM async_content WHERE doc_id = ?')
+        .get(docId);
 
       const id = (existing && existing.id) || _generateId();
 
       db.prepare(`
-        INSERT INTO async_content (id, room, content, author_id, author_name, saved_at)
+        INSERT INTO async_content (id, doc_id, content, author_id, author_name, saved_at)
         VALUES (?, ?, ?, ?, ?, ?)
-        ON CONFLICT(room) DO UPDATE SET
+        ON CONFLICT(doc_id) DO UPDATE SET
           content    = excluded.content,
           author_id  = excluded.author_id,
           author_name = excluded.author_name,
           saved_at   = excluded.saved_at
       `).run(
         id,
-        room,
+        docId,
         content,
         body.authorId || null,
         body.authorName || null,
         savedAt
       );
 
-      _ok(res, { room, saved_at: savedAt });
+      _ok(res, { doc_id: docId, saved_at: savedAt });
     } catch (err) {
       _bad(res, 500, err.message);
     }
   });
 
-  // Fetch the latest saved content for a room.
-  app.get('/collab/:room/content', (req, res) => {
+  // Fetch the latest saved content for a document.
+  app.get('/collab/:docId/content', (req, res) => {
     try {
       const row = db
-        .prepare('SELECT room, content, author_id, author_name, saved_at FROM async_content WHERE room = ?')
-        .get(req.params.room);
+        .prepare('SELECT doc_id, content, author_id, author_name, saved_at FROM async_content WHERE doc_id = ?')
+        .get(req.params.docId);
 
-      if (!row) return _bad(res, 404, 'no content saved for this room');
+      if (!row) return _bad(res, 404, 'no content saved for this document');
       _ok(res, row);
     } catch (err) {
       _bad(res, 500, err.message);

--- a/lib/async_save.js
+++ b/lib/async_save.js
@@ -1,0 +1,135 @@
+'use strict';
+
+// ─── Async editor content persistence ────────────────────────────────────────
+//
+// REST endpoints backed by SQLite for storing the latest editor HTML per room.
+// Called by the Froala save plugin (POST with body key "body") when the editor
+// runs in async/offline mode — i.e. when realTimeConfig.syncUrl is not set.
+//
+// Table (auto-created on first call to `attachRoutes`):
+//   async_content(id, room, content, author_id, author_name, saved_at)
+//
+// Each room has exactly one row — a POST always upserts the current content.
+
+let _db = null;
+
+function _getDb(dbPath) {
+  if (_db) return _db;
+
+  let Database;
+  try {
+    Database = require('better-sqlite3');
+  } catch (err) {
+    throw new Error(
+      '[async_save] better-sqlite3 is required. ' +
+      'Install it as a dev dependency: npm install --save-dev better-sqlite3'
+    );
+  }
+
+  _db = new Database(dbPath || 'collab.db');
+  _db.pragma('journal_mode = WAL');
+
+  _db.exec(`
+    CREATE TABLE IF NOT EXISTS async_content (
+      id TEXT PRIMARY KEY,
+      room TEXT NOT NULL UNIQUE,
+      content TEXT NOT NULL,
+      author_id TEXT,
+      author_name TEXT,
+      saved_at INTEGER NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_async_content_room ON async_content(room);
+  `);
+
+  return _db;
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function _ok(res, body, code) {
+  res.status(code || 200).json(body);
+}
+
+function _bad(res, code, msg) {
+  res.status(code).json({ error: msg });
+}
+
+function _generateId() {
+  return (
+    'ac-' +
+    Date.now().toString(36) +
+    '-' +
+    Math.random().toString(36).slice(2, 7)
+  );
+}
+
+// ─── Route registration ───────────────────────────────────────────────────────
+
+/**
+ * Attach the async-save REST endpoints to an Express app.
+ *
+ * @param {object} app          Express app instance
+ * @param {object} [options]
+ * @param {string} [options.dbPath='collab.db']  SQLite file path
+ */
+function attachRoutes(app, options) {
+  options = options || {};
+  const db = _getDb(options.dbPath);
+
+  // Save (upsert) the current editor content for a room.
+  // Called by the Froala save plugin — body key is "body" (saveParam default).
+  app.post('/collab/:room/content', (req, res) => {
+    const body = req.body || {};
+    const content = body.body;
+    if (content == null) return _bad(res, 400, '"body" field is required');
+
+    const room = req.params.room;
+    const savedAt = Date.now();
+
+    try {
+      const existing = db
+        .prepare('SELECT id FROM async_content WHERE room = ?')
+        .get(room);
+
+      const id = (existing && existing.id) || _generateId();
+
+      db.prepare(`
+        INSERT INTO async_content (id, room, content, author_id, author_name, saved_at)
+        VALUES (?, ?, ?, ?, ?, ?)
+        ON CONFLICT(room) DO UPDATE SET
+          content    = excluded.content,
+          author_id  = excluded.author_id,
+          author_name = excluded.author_name,
+          saved_at   = excluded.saved_at
+      `).run(
+        id,
+        room,
+        content,
+        body.authorId || null,
+        body.authorName || null,
+        savedAt
+      );
+
+      _ok(res, { room, saved_at: savedAt });
+    } catch (err) {
+      _bad(res, 500, err.message);
+    }
+  });
+
+  // Fetch the latest saved content for a room.
+  app.get('/collab/:room/content', (req, res) => {
+    try {
+      const row = db
+        .prepare('SELECT room, content, author_id, author_name, saved_at FROM async_content WHERE room = ?')
+        .get(req.params.room);
+
+      if (!row) return _bad(res, 404, 'no content saved for this room');
+      _ok(res, row);
+    } catch (err) {
+      _bad(res, 500, err.message);
+    }
+  });
+}
+
+exports.AsyncSave = { attachRoutes };

--- a/lib/async_save.js
+++ b/lib/async_save.js
@@ -11,58 +11,7 @@
 //
 // Each document has exactly one row — a POST always upserts the current content.
 
-let _db = null;
-
-function _getDb(dbPath) {
-  if (_db) return _db;
-
-  let Database;
-  try {
-    Database = require('better-sqlite3');
-  } catch (err) {
-    throw new Error(
-      '[async_save] better-sqlite3 is required. ' +
-      'Install it as a dev dependency: npm install --save-dev better-sqlite3'
-    );
-  }
-
-  _db = new Database(dbPath || 'collab.db');
-  _db.pragma('journal_mode = WAL');
-
-  _db.exec(`
-    CREATE TABLE IF NOT EXISTS async_content (
-      id TEXT PRIMARY KEY,
-      doc_id TEXT NOT NULL UNIQUE,
-      content TEXT NOT NULL,
-      author_id TEXT,
-      author_name TEXT,
-      saved_at INTEGER NOT NULL
-    );
-
-    CREATE INDEX IF NOT EXISTS idx_async_content_doc_id ON async_content(doc_id);
-  `);
-
-  return _db;
-}
-
-// ─── Helpers ─────────────────────────────────────────────────────────────────
-
-function _ok(res, body, code) {
-  res.status(code || 200).json(body);
-}
-
-function _bad(res, code, msg) {
-  res.status(code).json({ error: msg });
-}
-
-function _generateId() {
-  return (
-    'ac-' +
-    Date.now().toString(36) +
-    '-' +
-    Math.random().toString(36).slice(2, 7)
-  );
-}
+const { getDb, ok, bad, generateId } = require('./collab_db');
 
 // ─── Route registration ───────────────────────────────────────────────────────
 
@@ -75,14 +24,27 @@ function _generateId() {
  */
 function attachRoutes(app, options) {
   options = options || {};
-  const db = _getDb(options.dbPath);
+  const db = getDb(options.dbPath);
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS async_content (
+      id TEXT PRIMARY KEY,
+      doc_id TEXT NOT NULL UNIQUE,
+      content TEXT NOT NULL,
+      author_id TEXT,
+      author_name TEXT,
+      saved_at INTEGER NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_async_content_doc_id ON async_content(doc_id);
+  `);
 
   // Save (upsert) the current editor content for a document.
   // Called by the Froala save plugin — body key is "body" (saveParam default).
   app.post('/collab/:docId/content', (req, res) => {
     const body = req.body || {};
     const content = body.body;
-    if (content == null) return _bad(res, 400, '"body" field is required');
+    if (content == null) return bad(res, 400, '"body" field is required');
 
     const docId = req.params.docId;
     const savedAt = Date.now();
@@ -92,7 +54,7 @@ function attachRoutes(app, options) {
         .prepare('SELECT id FROM async_content WHERE doc_id = ?')
         .get(docId);
 
-      const id = (existing && existing.id) || _generateId();
+      const id = (existing && existing.id) || generateId('ac');
 
       db.prepare(`
         INSERT INTO async_content (id, doc_id, content, author_id, author_name, saved_at)
@@ -111,25 +73,28 @@ function attachRoutes(app, options) {
         savedAt
       );
 
-      _ok(res, { doc_id: docId, saved_at: savedAt });
+      ok(res, { doc_id: docId, saved_at: savedAt });
     } catch (err) {
-      _bad(res, 500, err.message);
+      bad(res, 500, err.message);
     }
   });
 
   // Fetch the latest saved content for a document.
+  // Content is returned verbatim; sanitization is the caller's responsibility.
   app.get('/collab/:docId/content', (req, res) => {
     try {
       const row = db
         .prepare('SELECT doc_id, content, author_id, author_name, saved_at FROM async_content WHERE doc_id = ?')
         .get(req.params.docId);
 
-      if (!row) return _bad(res, 404, 'no content saved for this document');
-      _ok(res, row);
+      if (!row) return bad(res, 404, 'no content saved for this document');
+      ok(res, row);
     } catch (err) {
-      _bad(res, 500, err.message);
+      bad(res, 500, err.message);
     }
   });
 }
 
+// Exported as a named property so server.js can destructure:
+//   var AsyncSave = FroalaEditor.AsyncSave;
 exports.AsyncSave = { attachRoutes };

--- a/lib/collab_db.js
+++ b/lib/collab_db.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const path = require('path');
+
+const _dbs = new Map();
+
+function _openDb(dbPath) {
+  const Database = require('better-sqlite3');
+  const db = new Database(dbPath);
+  db.pragma('journal_mode = WAL');
+  return db;
+}
+
+function getDb(dbPath) {
+  const key = dbPath || path.join(__dirname, '..', 'collab.db');
+  if (!_dbs.has(key)) _dbs.set(key, _openDb(key));
+  return _dbs.get(key);
+}
+
+process.on('exit', () => { _dbs.forEach(db => db.close()); });
+
+exports.getDb      = getDb;
+exports.ok         = (res, body, code) => res.status(code || 200).json(body);
+exports.bad        = (res, code, msg) => res.status(code).json({ error: msg });
+exports.generateId = (prefix) =>
+  `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 7)}`;

--- a/lib/collab_persistence.js
+++ b/lib/collab_persistence.js
@@ -2,35 +2,39 @@
 
 // ─── Collab persistence (suggestions + comments) ─────────────────────────────
 //
-// Plain-JSON REST endpoints backed by SQLite for local dev. The Node SDK has
-// anchor positions are stored as opaque JSON arrays
+// Plain-JSON REST endpoints backed by SQLite for local dev.
+// Anchor positions are stored as opaque JSON arrays
 // and never interpreted on the server.
 //
 // Tables (auto-created on first call to `attachRoutes`):
 //   suggestions(id, doc_id, type, author_id, author_name, timestamp,
-//               original_text, suggested_text, anchor_start, anchor_end, status)
+//               original_text, suggested_text, anchor_start, anchor_end, status, replies)
 //   comments(id, doc_id, author_id, author_name, timestamp, text,
 //            anchor_start, anchor_end, resolved, replies)
 
-let _db = null;
+const { getDb, ok, bad } = require('./collab_db');
 
-function _getDb(dbPath) {
-  if (_db) return _db;
+// ─── Helpers ─────────────────────────────────────────────────────────────────
 
-  let Database;
-  try {
-    Database = require('better-sqlite3');
-  } catch (err) {
-    throw new Error(
-      '[collab_persistence] better-sqlite3 is required. ' +
-      'Install it as a dev dependency: npm install --save-dev better-sqlite3'
-    );
-  }
+function _stringifyAnchor(anchor) {
+  if (anchor == null) return null;
+  return typeof anchor === 'string' ? anchor : JSON.stringify(anchor);
+}
 
-  _db = new Database(dbPath || 'collab.db');
-  _db.pragma('journal_mode = WAL');
+// ─── Route registration ─────────────────────────────────────────────────────
 
-  _db.exec(`
+/**
+ * Attach the suggestion + comment REST endpoints to an Express app.
+ *
+ * @param {object} app          Express app instance
+ * @param {object} [options]
+ * @param {string} [options.dbPath='collab.db']  SQLite file path
+ */
+function attachRoutes(app, options) {
+  options = options || {};
+  const db = getDb(options.dbPath);
+
+  db.exec(`
     CREATE TABLE IF NOT EXISTS suggestions (
       id TEXT PRIMARY KEY,
       doc_id TEXT NOT NULL,
@@ -65,58 +69,35 @@ function _getDb(dbPath) {
   `);
 
   // Add replies column to existing suggestions tables that predate this change.
-  try { _db.exec("ALTER TABLE suggestions ADD COLUMN replies TEXT DEFAULT '[]'"); } catch (_) {}
-
-  return _db;
-}
-
-// ─── Helpers ─────────────────────────────────────────────────────────────────
-
-function _stringifyAnchor(anchor) {
-  if (anchor == null) return null;
-  return typeof anchor === 'string' ? anchor : JSON.stringify(anchor);
-}
-
-function _ok(res, body, code) {
-  res.status(code || 200).json(body);
-}
-
-function _bad(res, code, msg) {
-  res.status(code).json({ error: msg });
-}
-
-// ─── Route registration ─────────────────────────────────────────────────────
-
-/**
- * Attach the suggestion + comment REST endpoints to an Express app.
- *
- * @param {object} app          Express app instance
- * @param {object} [options]
- * @param {string} [options.dbPath='collab.db']  SQLite file path
- */
-function attachRoutes(app, options) {
-  options = options || {};
-  const db = _getDb(options.dbPath);
+  try {
+    db.exec("ALTER TABLE suggestions ADD COLUMN replies TEXT DEFAULT '[]'");
+  } catch (err) {
+    if (!err.message.includes('duplicate column name')) throw err;
+  }
 
   // ── Suggestions ──────────────────────────────────────────────────────────
 
   app.get('/collab/:docId/suggestions', (req, res) => {
     try {
       const rows = db
-        .prepare('SELECT * FROM suggestions WHERE doc_id = ? ORDER BY timestamp ASC')
+        .prepare(`
+          SELECT id, doc_id, type, author_id, author_name, timestamp,
+                 original_text, suggested_text, anchor_start, anchor_end, status
+          FROM suggestions WHERE doc_id = ? ORDER BY timestamp ASC
+        `)
         .all(req.params.docId);
-      _ok(res, rows);
+      ok(res, rows);
     } catch (err) {
-      _bad(res, 500, err.message);
+      bad(res, 500, err.message);
     }
   });
 
   app.post('/collab/:docId/suggestions', (req, res) => {
     const s = req.body || {};
-    if (!s.id || !s.type) return _bad(res, 400, 'id and type are required');
+    if (!s.id || !s.type) return bad(res, 400, 'id and type are required');
 
     try {
-      db.prepare(`
+      const info = db.prepare(`
         INSERT OR IGNORE INTO suggestions
         (id, doc_id, type, author_id, author_name, timestamp,
          original_text, suggested_text, anchor_start, anchor_end, status)
@@ -134,9 +115,10 @@ function attachRoutes(app, options) {
         _stringifyAnchor(s.anchor && s.anchor.end),
         s.status || 'pending'
       );
-      _ok(res, { id: s.id }, 201);
+      if (info.changes === 0) return bad(res, 409, 'suggestion already exists');
+      ok(res, { id: s.id }, 201);
     } catch (err) {
-      _bad(res, 500, err.message);
+      bad(res, 500, err.message);
     }
   });
 
@@ -146,10 +128,10 @@ function attachRoutes(app, options) {
     const hasReplies = 'replies' in body;
 
     if (!hasStatus && !hasReplies) {
-      return _bad(res, 400, 'status or replies required');
+      return bad(res, 400, 'status or replies required');
     }
     if (hasStatus && !['pending', 'accepted', 'rejected'].includes(body.status)) {
-      return _bad(res, 400, 'invalid status');
+      return bad(res, 400, 'invalid status');
     }
 
     try {
@@ -161,9 +143,9 @@ function attachRoutes(app, options) {
         db.prepare('UPDATE suggestions SET replies = ? WHERE id = ? AND doc_id = ?')
           .run(JSON.stringify(body.replies || []), req.params.id, req.params.docId);
       }
-      _ok(res, { id: req.params.id, ...(hasStatus ? { status: body.status } : {}) });
+      ok(res, { id: req.params.id, ...(hasStatus ? { status: body.status } : {}) });
     } catch (err) {
-      _bad(res, 500, err.message);
+      bad(res, 500, err.message);
     }
   });
 
@@ -173,7 +155,7 @@ function attachRoutes(app, options) {
         .run(req.params.id, req.params.docId);
       res.sendStatus(204);
     } catch (err) {
-      _bad(res, 500, err.message);
+      bad(res, 500, err.message);
     }
   });
 
@@ -182,20 +164,24 @@ function attachRoutes(app, options) {
   app.get('/collab/:docId/comments', (req, res) => {
     try {
       const rows = db
-        .prepare('SELECT * FROM comments WHERE doc_id = ? ORDER BY timestamp ASC')
+        .prepare(`
+          SELECT id, doc_id, author_id, author_name, timestamp,
+                 text, anchor_start, anchor_end, resolved
+          FROM comments WHERE doc_id = ? ORDER BY timestamp ASC
+        `)
         .all(req.params.docId);
-      _ok(res, rows);
+      ok(res, rows);
     } catch (err) {
-      _bad(res, 500, err.message);
+      bad(res, 500, err.message);
     }
   });
 
   app.post('/collab/:docId/comments', (req, res) => {
     const c = req.body || {};
-    if (!c.id) return _bad(res, 400, 'id is required');
+    if (!c.id) return bad(res, 400, 'id is required');
 
     try {
-      db.prepare(`
+      const info = db.prepare(`
         INSERT OR IGNORE INTO comments
         (id, doc_id, author_id, author_name, timestamp, text,
          anchor_start, anchor_end, resolved, replies)
@@ -212,26 +198,38 @@ function attachRoutes(app, options) {
         c.resolved ? 1 : 0,
         JSON.stringify(c.replies || [])
       );
-      _ok(res, { id: c.id }, 201);
+      if (info.changes === 0) return bad(res, 409, 'comment already exists');
+      ok(res, { id: c.id }, 201);
     } catch (err) {
-      _bad(res, 500, err.message);
+      bad(res, 500, err.message);
     }
   });
 
   app.patch('/collab/:docId/comments/:id', (req, res) => {
     const body = req.body || {};
+    const hasResolved = 'resolved' in body;
+    const hasReplies = 'replies' in body;
+
+    if (!hasResolved && !hasReplies) {
+      return bad(res, 400, 'resolved or replies required');
+    }
+
     try {
-      if ('resolved' in body) {
-        db.prepare('UPDATE comments SET resolved = ? WHERE id = ? AND doc_id = ?')
+      let updated = false;
+      if (hasResolved) {
+        const info = db.prepare('UPDATE comments SET resolved = ? WHERE id = ? AND doc_id = ?')
           .run(body.resolved ? 1 : 0, req.params.id, req.params.docId);
+        if (info.changes > 0) updated = true;
       }
-      if ('replies' in body) {
-        db.prepare('UPDATE comments SET replies = ? WHERE id = ? AND doc_id = ?')
+      if (hasReplies) {
+        const info = db.prepare('UPDATE comments SET replies = ? WHERE id = ? AND doc_id = ?')
           .run(JSON.stringify(body.replies || []), req.params.id, req.params.docId);
+        if (info.changes > 0) updated = true;
       }
-      _ok(res, { id: req.params.id });
+      if (!updated) return bad(res, 404, 'comment not found');
+      ok(res, { id: req.params.id });
     } catch (err) {
-      _bad(res, 500, err.message);
+      bad(res, 500, err.message);
     }
   });
 
@@ -241,9 +239,11 @@ function attachRoutes(app, options) {
         .run(req.params.id, req.params.docId);
       res.sendStatus(204);
     } catch (err) {
-      _bad(res, 500, err.message);
+      bad(res, 500, err.message);
     }
   });
 }
 
+// Exported as a named property so server.js can destructure:
+//   var CollabPersistence = FroalaEditor.CollabPersistence;
 exports.CollabPersistence = { attachRoutes };

--- a/lib/collab_persistence.js
+++ b/lib/collab_persistence.js
@@ -33,7 +33,7 @@ function _stringifyAnchor(anchor) {
 function attachRoutes(app, options) {
   options = options || {};
   const db = getDb(options.dbPath);
-  const auth = options.authMiddleware || function(req, res, next) { next(); };
+  const auth = options.authMiddleware || function (req, res, next) { next(); };
   app.use('/collab', auth);
 
   db.exec(`
@@ -100,11 +100,24 @@ function attachRoutes(app, options) {
     if (!s.id || !s.type) return bad(res, 400, 'id and type are required');
 
     try {
-      const info = db.prepare(`
-        INSERT OR IGNORE INTO suggestions
+      const exists = db.prepare('SELECT 1 FROM suggestions WHERE id = ?').get(s.id);
+
+      db.prepare(`
+        INSERT INTO suggestions
         (id, doc_id, type, author_id, author_name, timestamp,
          original_text, suggested_text, anchor_start, anchor_end, status)
         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(id) DO UPDATE SET
+          doc_id         = excluded.doc_id,
+          type           = excluded.type,
+          author_id      = excluded.author_id,
+          author_name    = excluded.author_name,
+          timestamp      = excluded.timestamp,
+          original_text  = excluded.original_text,
+          suggested_text = excluded.suggested_text,
+          anchor_start   = excluded.anchor_start,
+          anchor_end     = excluded.anchor_end,
+          status         = excluded.status
       `).run(
         s.id,
         req.params.docId,
@@ -118,8 +131,7 @@ function attachRoutes(app, options) {
         _stringifyAnchor(s.anchor && s.anchor.end),
         s.status || 'pending'
       );
-      if (info.changes === 0) return bad(res, 409, 'suggestion already exists');
-      ok(res, { id: s.id }, 201);
+      ok(res, { id: s.id, updated: !!exists }, exists ? 200 : 201);
     } catch (err) {
       // eslint-disable-next-line no-console
       console.error('[collab] db error:', err);

--- a/lib/collab_persistence.js
+++ b/lib/collab_persistence.js
@@ -1,0 +1,249 @@
+'use strict';
+
+// ─── Collab persistence (suggestions + comments) ─────────────────────────────
+//
+// Plain-JSON REST endpoints backed by SQLite for local dev. The Node SDK has
+// anchor positions are stored as opaque JSON arrays
+// and never interpreted on the server.
+//
+// Tables (auto-created on first call to `attachRoutes`):
+//   suggestions(id, room, type, author_id, author_name, timestamp,
+//               original_text, suggested_text, anchor_start, anchor_end, status)
+//   comments(id, room, author_id, author_name, timestamp, text,
+//            anchor_start, anchor_end, resolved, replies)
+
+let _db = null;
+
+function _getDb(dbPath) {
+  if (_db) return _db;
+
+  let Database;
+  try {
+    Database = require('better-sqlite3');
+  } catch (err) {
+    throw new Error(
+      '[collab_persistence] better-sqlite3 is required. ' +
+      'Install it as a dev dependency: npm install --save-dev better-sqlite3'
+    );
+  }
+
+  _db = new Database(dbPath || 'collab.db');
+  _db.pragma('journal_mode = WAL');
+
+  _db.exec(`
+    CREATE TABLE IF NOT EXISTS suggestions (
+      id TEXT PRIMARY KEY,
+      room TEXT NOT NULL,
+      type TEXT NOT NULL,
+      author_id TEXT,
+      author_name TEXT,
+      timestamp INTEGER,
+      original_text TEXT,
+      suggested_text TEXT,
+      anchor_start TEXT,
+      anchor_end TEXT,
+      status TEXT DEFAULT 'pending',
+      replies TEXT DEFAULT '[]'
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_suggestions_room ON suggestions(room);
+
+    CREATE TABLE IF NOT EXISTS comments (
+      id TEXT PRIMARY KEY,
+      room TEXT NOT NULL,
+      author_id TEXT,
+      author_name TEXT,
+      timestamp INTEGER,
+      text TEXT,
+      anchor_start TEXT,
+      anchor_end TEXT,
+      resolved INTEGER DEFAULT 0,
+      replies TEXT DEFAULT '[]'
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_comments_room ON comments(room);
+  `);
+
+  // Add replies column to existing suggestions tables that predate this change.
+  try { _db.exec("ALTER TABLE suggestions ADD COLUMN replies TEXT DEFAULT '[]'"); } catch (_) {}
+
+  return _db;
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function _stringifyAnchor(anchor) {
+  if (anchor == null) return null;
+  return typeof anchor === 'string' ? anchor : JSON.stringify(anchor);
+}
+
+function _ok(res, body, code) {
+  res.status(code || 200).json(body);
+}
+
+function _bad(res, code, msg) {
+  res.status(code).json({ error: msg });
+}
+
+// ─── Route registration ─────────────────────────────────────────────────────
+
+/**
+ * Attach the suggestion + comment REST endpoints to an Express app.
+ *
+ * @param {object} app          Express app instance
+ * @param {object} [options]
+ * @param {string} [options.dbPath='collab.db']  SQLite file path
+ */
+function attachRoutes(app, options) {
+  options = options || {};
+  const db = _getDb(options.dbPath);
+
+  // ── Suggestions ──────────────────────────────────────────────────────────
+
+  app.get('/collab/:room/suggestions', (req, res) => {
+    try {
+      const rows = db
+        .prepare('SELECT * FROM suggestions WHERE room = ? ORDER BY timestamp ASC')
+        .all(req.params.room);
+      _ok(res, rows);
+    } catch (err) {
+      _bad(res, 500, err.message);
+    }
+  });
+
+  app.post('/collab/:room/suggestions', (req, res) => {
+    const s = req.body || {};
+    if (!s.id || !s.type) return _bad(res, 400, 'id and type are required');
+
+    try {
+      db.prepare(`
+        INSERT OR IGNORE INTO suggestions
+        (id, room, type, author_id, author_name, timestamp,
+         original_text, suggested_text, anchor_start, anchor_end, status)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        s.id,
+        req.params.room,
+        s.type,
+        s.authorId || null,
+        s.authorName || null,
+        s.timestamp || Date.now(),
+        s.originalText == null ? null : s.originalText,
+        s.suggestedText == null ? null : s.suggestedText,
+        _stringifyAnchor(s.anchor && s.anchor.start),
+        _stringifyAnchor(s.anchor && s.anchor.end),
+        s.status || 'pending'
+      );
+      _ok(res, { id: s.id }, 201);
+    } catch (err) {
+      _bad(res, 500, err.message);
+    }
+  });
+
+  app.patch('/collab/:room/suggestions/:id', (req, res) => {
+    const body = req.body || {};
+    const hasStatus = 'status' in body;
+    const hasReplies = 'replies' in body;
+
+    if (!hasStatus && !hasReplies) {
+      return _bad(res, 400, 'status or replies required');
+    }
+    if (hasStatus && !['pending', 'accepted', 'rejected'].includes(body.status)) {
+      return _bad(res, 400, 'invalid status');
+    }
+
+    try {
+      if (hasStatus) {
+        db.prepare('UPDATE suggestions SET status = ? WHERE id = ? AND room = ?')
+          .run(body.status, req.params.id, req.params.room);
+      }
+      if (hasReplies) {
+        db.prepare('UPDATE suggestions SET replies = ? WHERE id = ? AND room = ?')
+          .run(JSON.stringify(body.replies || []), req.params.id, req.params.room);
+      }
+      _ok(res, { id: req.params.id, ...(hasStatus ? { status: body.status } : {}) });
+    } catch (err) {
+      _bad(res, 500, err.message);
+    }
+  });
+
+  app.delete('/collab/:room/suggestions/:id', (req, res) => {
+    try {
+      db.prepare('DELETE FROM suggestions WHERE id = ? AND room = ?')
+        .run(req.params.id, req.params.room);
+      res.sendStatus(204);
+    } catch (err) {
+      _bad(res, 500, err.message);
+    }
+  });
+
+  // ── Comments ─────────────────────────────────────────────────────────────
+
+  app.get('/collab/:room/comments', (req, res) => {
+    try {
+      const rows = db
+        .prepare('SELECT * FROM comments WHERE room = ? ORDER BY timestamp ASC')
+        .all(req.params.room);
+      _ok(res, rows);
+    } catch (err) {
+      _bad(res, 500, err.message);
+    }
+  });
+
+  app.post('/collab/:room/comments', (req, res) => {
+    const c = req.body || {};
+    if (!c.id) return _bad(res, 400, 'id is required');
+
+    try {
+      db.prepare(`
+        INSERT OR IGNORE INTO comments
+        (id, room, author_id, author_name, timestamp, text,
+         anchor_start, anchor_end, resolved, replies)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        c.id,
+        req.params.room,
+        c.authorId || null,
+        c.authorName || null,
+        c.timestamp || Date.now(),
+        c.text || '',
+        _stringifyAnchor(c.anchor && c.anchor.start),
+        _stringifyAnchor(c.anchor && c.anchor.end),
+        c.resolved ? 1 : 0,
+        JSON.stringify(c.replies || [])
+      );
+      _ok(res, { id: c.id }, 201);
+    } catch (err) {
+      _bad(res, 500, err.message);
+    }
+  });
+
+  app.patch('/collab/:room/comments/:id', (req, res) => {
+    const body = req.body || {};
+    try {
+      if ('resolved' in body) {
+        db.prepare('UPDATE comments SET resolved = ? WHERE id = ? AND room = ?')
+          .run(body.resolved ? 1 : 0, req.params.id, req.params.room);
+      }
+      if ('replies' in body) {
+        db.prepare('UPDATE comments SET replies = ? WHERE id = ? AND room = ?')
+          .run(JSON.stringify(body.replies || []), req.params.id, req.params.room);
+      }
+      _ok(res, { id: req.params.id });
+    } catch (err) {
+      _bad(res, 500, err.message);
+    }
+  });
+
+  app.delete('/collab/:room/comments/:id', (req, res) => {
+    try {
+      db.prepare('DELETE FROM comments WHERE id = ? AND room = ?')
+        .run(req.params.id, req.params.room);
+      res.sendStatus(204);
+    } catch (err) {
+      _bad(res, 500, err.message);
+    }
+  });
+}
+
+exports.CollabPersistence = { attachRoutes };

--- a/lib/collab_persistence.js
+++ b/lib/collab_persistence.js
@@ -33,6 +33,8 @@ function _stringifyAnchor(anchor) {
 function attachRoutes(app, options) {
   options = options || {};
   const db = getDb(options.dbPath);
+  const auth = options.authMiddleware || function(req, res, next) { next(); };
+  app.use('/collab', auth);
 
   db.exec(`
     CREATE TABLE IF NOT EXISTS suggestions (
@@ -69,10 +71,9 @@ function attachRoutes(app, options) {
   `);
 
   // Add replies column to existing suggestions tables that predate this change.
-  try {
+  const sugCols = db.pragma('table_info(suggestions)').map(r => r.name);
+  if (!sugCols.includes('replies')) {
     db.exec("ALTER TABLE suggestions ADD COLUMN replies TEXT DEFAULT '[]'");
-  } catch (err) {
-    if (!err.message.includes('duplicate column name')) throw err;
   }
 
   // ── Suggestions ──────────────────────────────────────────────────────────
@@ -82,13 +83,15 @@ function attachRoutes(app, options) {
       const rows = db
         .prepare(`
           SELECT id, doc_id, type, author_id, author_name, timestamp,
-                 original_text, suggested_text, anchor_start, anchor_end, status
+                 original_text, suggested_text, anchor_start, anchor_end, status, replies
           FROM suggestions WHERE doc_id = ? ORDER BY timestamp ASC
         `)
         .all(req.params.docId);
       ok(res, rows);
     } catch (err) {
-      bad(res, 500, err.message);
+      // eslint-disable-next-line no-console
+      console.error('[collab] db error:', err);
+      bad(res, 500, 'internal server error');
     }
   });
 
@@ -118,7 +121,9 @@ function attachRoutes(app, options) {
       if (info.changes === 0) return bad(res, 409, 'suggestion already exists');
       ok(res, { id: s.id }, 201);
     } catch (err) {
-      bad(res, 500, err.message);
+      // eslint-disable-next-line no-console
+      console.error('[collab] db error:', err);
+      bad(res, 500, 'internal server error');
     }
   });
 
@@ -135,17 +140,17 @@ function attachRoutes(app, options) {
     }
 
     try {
-      if (hasStatus) {
-        db.prepare('UPDATE suggestions SET status = ? WHERE id = ? AND doc_id = ?')
-          .run(body.status, req.params.id, req.params.docId);
-      }
-      if (hasReplies) {
-        db.prepare('UPDATE suggestions SET replies = ? WHERE id = ? AND doc_id = ?')
-          .run(JSON.stringify(body.replies || []), req.params.id, req.params.docId);
-      }
+      const sets = [], params = [];
+      if (hasStatus) { sets.push('status = ?'); params.push(body.status); }
+      if (hasReplies) { sets.push('replies = ?'); params.push(JSON.stringify(body.replies || [])); }
+      params.push(req.params.id, req.params.docId);
+      db.prepare(`UPDATE suggestions SET ${sets.join(', ')} WHERE id = ? AND doc_id = ?`)
+        .run(...params);
       ok(res, { id: req.params.id, ...(hasStatus ? { status: body.status } : {}) });
     } catch (err) {
-      bad(res, 500, err.message);
+      // eslint-disable-next-line no-console
+      console.error('[collab] db error:', err);
+      bad(res, 500, 'internal server error');
     }
   });
 
@@ -155,7 +160,9 @@ function attachRoutes(app, options) {
         .run(req.params.id, req.params.docId);
       res.sendStatus(204);
     } catch (err) {
-      bad(res, 500, err.message);
+      // eslint-disable-next-line no-console
+      console.error('[collab] db error:', err);
+      bad(res, 500, 'internal server error');
     }
   });
 
@@ -166,13 +173,15 @@ function attachRoutes(app, options) {
       const rows = db
         .prepare(`
           SELECT id, doc_id, author_id, author_name, timestamp,
-                 text, anchor_start, anchor_end, resolved
+                 text, anchor_start, anchor_end, resolved, replies
           FROM comments WHERE doc_id = ? ORDER BY timestamp ASC
         `)
         .all(req.params.docId);
       ok(res, rows);
     } catch (err) {
-      bad(res, 500, err.message);
+      // eslint-disable-next-line no-console
+      console.error('[collab] db error:', err);
+      bad(res, 500, 'internal server error');
     }
   });
 
@@ -201,7 +210,9 @@ function attachRoutes(app, options) {
       if (info.changes === 0) return bad(res, 409, 'comment already exists');
       ok(res, { id: c.id }, 201);
     } catch (err) {
-      bad(res, 500, err.message);
+      // eslint-disable-next-line no-console
+      console.error('[collab] db error:', err);
+      bad(res, 500, 'internal server error');
     }
   });
 
@@ -215,21 +226,18 @@ function attachRoutes(app, options) {
     }
 
     try {
-      let updated = false;
-      if (hasResolved) {
-        const info = db.prepare('UPDATE comments SET resolved = ? WHERE id = ? AND doc_id = ?')
-          .run(body.resolved ? 1 : 0, req.params.id, req.params.docId);
-        if (info.changes > 0) updated = true;
-      }
-      if (hasReplies) {
-        const info = db.prepare('UPDATE comments SET replies = ? WHERE id = ? AND doc_id = ?')
-          .run(JSON.stringify(body.replies || []), req.params.id, req.params.docId);
-        if (info.changes > 0) updated = true;
-      }
-      if (!updated) return bad(res, 404, 'comment not found');
+      const sets = [], params = [];
+      if (hasResolved) { sets.push('resolved = ?'); params.push(body.resolved ? 1 : 0); }
+      if (hasReplies) { sets.push('replies = ?'); params.push(JSON.stringify(body.replies || [])); }
+      params.push(req.params.id, req.params.docId);
+      const info = db.prepare(`UPDATE comments SET ${sets.join(', ')} WHERE id = ? AND doc_id = ?`)
+        .run(...params);
+      if (info.changes === 0) return bad(res, 404, 'comment not found');
       ok(res, { id: req.params.id });
     } catch (err) {
-      bad(res, 500, err.message);
+      // eslint-disable-next-line no-console
+      console.error('[collab] db error:', err);
+      bad(res, 500, 'internal server error');
     }
   });
 
@@ -239,7 +247,9 @@ function attachRoutes(app, options) {
         .run(req.params.id, req.params.docId);
       res.sendStatus(204);
     } catch (err) {
-      bad(res, 500, err.message);
+      // eslint-disable-next-line no-console
+      console.error('[collab] db error:', err);
+      bad(res, 500, 'internal server error');
     }
   });
 }

--- a/lib/collab_persistence.js
+++ b/lib/collab_persistence.js
@@ -7,9 +7,9 @@
 // and never interpreted on the server.
 //
 // Tables (auto-created on first call to `attachRoutes`):
-//   suggestions(id, room, type, author_id, author_name, timestamp,
+//   suggestions(id, doc_id, type, author_id, author_name, timestamp,
 //               original_text, suggested_text, anchor_start, anchor_end, status)
-//   comments(id, room, author_id, author_name, timestamp, text,
+//   comments(id, doc_id, author_id, author_name, timestamp, text,
 //            anchor_start, anchor_end, resolved, replies)
 
 let _db = null;
@@ -33,7 +33,7 @@ function _getDb(dbPath) {
   _db.exec(`
     CREATE TABLE IF NOT EXISTS suggestions (
       id TEXT PRIMARY KEY,
-      room TEXT NOT NULL,
+      doc_id TEXT NOT NULL,
       type TEXT NOT NULL,
       author_id TEXT,
       author_name TEXT,
@@ -46,11 +46,11 @@ function _getDb(dbPath) {
       replies TEXT DEFAULT '[]'
     );
 
-    CREATE INDEX IF NOT EXISTS idx_suggestions_room ON suggestions(room);
+    CREATE INDEX IF NOT EXISTS idx_suggestions_doc_id ON suggestions(doc_id);
 
     CREATE TABLE IF NOT EXISTS comments (
       id TEXT PRIMARY KEY,
-      room TEXT NOT NULL,
+      doc_id TEXT NOT NULL,
       author_id TEXT,
       author_name TEXT,
       timestamp INTEGER,
@@ -61,7 +61,7 @@ function _getDb(dbPath) {
       replies TEXT DEFAULT '[]'
     );
 
-    CREATE INDEX IF NOT EXISTS idx_comments_room ON comments(room);
+    CREATE INDEX IF NOT EXISTS idx_comments_doc_id ON comments(doc_id);
   `);
 
   // Add replies column to existing suggestions tables that predate this change.
@@ -100,30 +100,30 @@ function attachRoutes(app, options) {
 
   // ── Suggestions ──────────────────────────────────────────────────────────
 
-  app.get('/collab/:room/suggestions', (req, res) => {
+  app.get('/collab/:docId/suggestions', (req, res) => {
     try {
       const rows = db
-        .prepare('SELECT * FROM suggestions WHERE room = ? ORDER BY timestamp ASC')
-        .all(req.params.room);
+        .prepare('SELECT * FROM suggestions WHERE doc_id = ? ORDER BY timestamp ASC')
+        .all(req.params.docId);
       _ok(res, rows);
     } catch (err) {
       _bad(res, 500, err.message);
     }
   });
 
-  app.post('/collab/:room/suggestions', (req, res) => {
+  app.post('/collab/:docId/suggestions', (req, res) => {
     const s = req.body || {};
     if (!s.id || !s.type) return _bad(res, 400, 'id and type are required');
 
     try {
       db.prepare(`
         INSERT OR IGNORE INTO suggestions
-        (id, room, type, author_id, author_name, timestamp,
+        (id, doc_id, type, author_id, author_name, timestamp,
          original_text, suggested_text, anchor_start, anchor_end, status)
         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `).run(
         s.id,
-        req.params.room,
+        req.params.docId,
         s.type,
         s.authorId || null,
         s.authorName || null,
@@ -140,7 +140,7 @@ function attachRoutes(app, options) {
     }
   });
 
-  app.patch('/collab/:room/suggestions/:id', (req, res) => {
+  app.patch('/collab/:docId/suggestions/:id', (req, res) => {
     const body = req.body || {};
     const hasStatus = 'status' in body;
     const hasReplies = 'replies' in body;
@@ -154,12 +154,12 @@ function attachRoutes(app, options) {
 
     try {
       if (hasStatus) {
-        db.prepare('UPDATE suggestions SET status = ? WHERE id = ? AND room = ?')
-          .run(body.status, req.params.id, req.params.room);
+        db.prepare('UPDATE suggestions SET status = ? WHERE id = ? AND doc_id = ?')
+          .run(body.status, req.params.id, req.params.docId);
       }
       if (hasReplies) {
-        db.prepare('UPDATE suggestions SET replies = ? WHERE id = ? AND room = ?')
-          .run(JSON.stringify(body.replies || []), req.params.id, req.params.room);
+        db.prepare('UPDATE suggestions SET replies = ? WHERE id = ? AND doc_id = ?')
+          .run(JSON.stringify(body.replies || []), req.params.id, req.params.docId);
       }
       _ok(res, { id: req.params.id, ...(hasStatus ? { status: body.status } : {}) });
     } catch (err) {
@@ -167,10 +167,10 @@ function attachRoutes(app, options) {
     }
   });
 
-  app.delete('/collab/:room/suggestions/:id', (req, res) => {
+  app.delete('/collab/:docId/suggestions/:id', (req, res) => {
     try {
-      db.prepare('DELETE FROM suggestions WHERE id = ? AND room = ?')
-        .run(req.params.id, req.params.room);
+      db.prepare('DELETE FROM suggestions WHERE id = ? AND doc_id = ?')
+        .run(req.params.id, req.params.docId);
       res.sendStatus(204);
     } catch (err) {
       _bad(res, 500, err.message);
@@ -179,30 +179,30 @@ function attachRoutes(app, options) {
 
   // ── Comments ─────────────────────────────────────────────────────────────
 
-  app.get('/collab/:room/comments', (req, res) => {
+  app.get('/collab/:docId/comments', (req, res) => {
     try {
       const rows = db
-        .prepare('SELECT * FROM comments WHERE room = ? ORDER BY timestamp ASC')
-        .all(req.params.room);
+        .prepare('SELECT * FROM comments WHERE doc_id = ? ORDER BY timestamp ASC')
+        .all(req.params.docId);
       _ok(res, rows);
     } catch (err) {
       _bad(res, 500, err.message);
     }
   });
 
-  app.post('/collab/:room/comments', (req, res) => {
+  app.post('/collab/:docId/comments', (req, res) => {
     const c = req.body || {};
     if (!c.id) return _bad(res, 400, 'id is required');
 
     try {
       db.prepare(`
         INSERT OR IGNORE INTO comments
-        (id, room, author_id, author_name, timestamp, text,
+        (id, doc_id, author_id, author_name, timestamp, text,
          anchor_start, anchor_end, resolved, replies)
         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `).run(
         c.id,
-        req.params.room,
+        req.params.docId,
         c.authorId || null,
         c.authorName || null,
         c.timestamp || Date.now(),
@@ -218,16 +218,16 @@ function attachRoutes(app, options) {
     }
   });
 
-  app.patch('/collab/:room/comments/:id', (req, res) => {
+  app.patch('/collab/:docId/comments/:id', (req, res) => {
     const body = req.body || {};
     try {
       if ('resolved' in body) {
-        db.prepare('UPDATE comments SET resolved = ? WHERE id = ? AND room = ?')
-          .run(body.resolved ? 1 : 0, req.params.id, req.params.room);
+        db.prepare('UPDATE comments SET resolved = ? WHERE id = ? AND doc_id = ?')
+          .run(body.resolved ? 1 : 0, req.params.id, req.params.docId);
       }
       if ('replies' in body) {
-        db.prepare('UPDATE comments SET replies = ? WHERE id = ? AND room = ?')
-          .run(JSON.stringify(body.replies || []), req.params.id, req.params.room);
+        db.prepare('UPDATE comments SET replies = ? WHERE id = ? AND doc_id = ?')
+          .run(JSON.stringify(body.replies || []), req.params.id, req.params.docId);
       }
       _ok(res, { id: req.params.id });
     } catch (err) {
@@ -235,10 +235,10 @@ function attachRoutes(app, options) {
     }
   });
 
-  app.delete('/collab/:room/comments/:id', (req, res) => {
+  app.delete('/collab/:docId/comments/:id', (req, res) => {
     try {
-      db.prepare('DELETE FROM comments WHERE id = ? AND room = ?')
-        .run(req.params.id, req.params.room);
+      db.prepare('DELETE FROM comments WHERE id = ? AND doc_id = ?')
+        .run(req.params.id, req.params.docId);
       res.sendStatus(204);
     } catch (err) {
       _bad(res, 500, err.message);

--- a/lib/collaborative.js
+++ b/lib/collaborative.js
@@ -1,0 +1,102 @@
+'use strict';
+
+const WebSocket = require('ws');
+
+// ─── Structured logger ────────────────────────────────────────────────────────
+
+function log(level, msg, extra) {
+  // eslint-disable-next-line no-console
+  console.log(JSON.stringify({ ts: new Date().toISOString(), level, msg, ...extra }));
+}
+
+// ─── Room registry ────────────────────────────────────────────────────────────
+//
+// The server is a pure relay: it groups connections by room and broadcasts
+// every incoming message to the other members of that room. All collaboration
+// logic lives in the browser clients.
+//
+// Trade-off: a client that joins an empty room receives no historical state
+// until another peer reconnects. For an in-memory relay this is acceptable;
+// durable state (Redis, LevelDB, etc.) would belong here if persistence is needed.
+
+const rooms = new Map(); // roomName → Set<WebSocket>
+
+// ─── Core connection handler ──────────────────────────────────────────────────
+
+function setupWSConnection(conn, req) {
+  const roomName = decodeURIComponent(
+    (req.url || '/').replace(/^\//, '').split('?')[0] || 'default-room'
+  );
+
+  if (!rooms.has(roomName)) rooms.set(roomName, new Set());
+  const room = rooms.get(roomName);
+  room.add(conn);
+
+  log('info', 'client connected', { room: roomName, peers: room.size });
+
+  conn.on('message', (message) => {
+    // Relay to every other peer in the room — no parsing, no protocol knowledge.
+    for (const peer of room) {
+      if (peer !== conn && peer.readyState === WebSocket.OPEN) {
+        peer.send(message);
+      }
+    }
+  });
+
+  conn.on('close', () => {
+    room.delete(conn);
+    if (room.size === 0) rooms.delete(roomName);
+    log('info', 'client disconnected', { room: roomName, peers: room.size });
+  });
+
+  conn.on('error', (err) => {
+    log('error', 'socket error', { room: roomName, error: err.message });
+    room.delete(conn);
+    if (room.size === 0) rooms.delete(roomName);
+  });
+}
+
+// ─── Stats (for /health) ──────────────────────────────────────────────────────
+
+function getStats() {
+  let clients = 0;
+  rooms.forEach(room => { clients += room.size; });
+  return { rooms: rooms.size, clients };
+}
+
+// ─── Standalone server ────────────────────────────────────────────────────────
+
+function createServer(options = {}) {
+  const http = require('http');
+
+  const httpServer = http.createServer((req, res) => {
+    if (req.url === '/health' && req.method === 'GET') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(getStats()));
+      return;
+    }
+    res.writeHead(426, { 'Content-Type': 'text/plain' });
+    res.end('WebSocket connections only');
+  });
+
+  const wss = new WebSocket.Server({ server: httpServer });
+  wss.on('connection', setupWSConnection);
+
+  const port = options.port || 3000;
+  httpServer.listen(port, () => {
+    log('info', 'collaborative relay server started', { port });
+  });
+
+  return wss;
+}
+
+// ─── Attach to existing HTTP / Express server ─────────────────────────────────
+
+function attachToServer(httpServer) {
+  const wss = new WebSocket.Server({ server: httpServer });
+  wss.on('connection', setupWSConnection);
+  log('info', 'collaborative relay server attached to existing HTTP server');
+  return wss;
+}
+
+exports.Collaborative = { setupWSConnection, createServer, attachToServer, getStats };

--- a/lib/collaborative.js
+++ b/lib/collaborative.js
@@ -11,32 +11,32 @@ function log(level, msg, extra) {
 
 // ─── Room registry ────────────────────────────────────────────────────────────
 //
-// The server is a pure relay: it groups connections by room and broadcasts
-// every incoming message to the other members of that room. All collaboration
+// The server is a pure relay: it groups connections by docId and broadcasts
+// every incoming message to the other members of that document. All collaboration
 // logic lives in the browser clients.
 //
-// Trade-off: a client that joins an empty room receives no historical state
+// Trade-off: a client that joins an empty document receives no historical state
 // until another peer reconnects. For an in-memory relay this is acceptable;
 // durable state (Redis, LevelDB, etc.) would belong here if persistence is needed.
 
-const rooms = new Map(); // roomName → Set<WebSocket>
+const docs = new Map(); // docId → Set<WebSocket>
 
 // ─── Core connection handler ──────────────────────────────────────────────────
 
 function setupWSConnection(conn, req) {
-  const roomName = decodeURIComponent(
-    (req.url || '/').replace(/^\//, '').split('?')[0] || 'default-room'
+  const docId = decodeURIComponent(
+    (req.url || '/').replace(/^\//, '').split('?')[0] || 'default-doc'
   );
 
-  if (!rooms.has(roomName)) rooms.set(roomName, new Set());
-  const room = rooms.get(roomName);
-  room.add(conn);
+  if (!docs.has(docId)) docs.set(docId, new Set());
+  const doc = docs.get(docId);
+  doc.add(conn);
 
-  log('info', 'client connected', { room: roomName, peers: room.size });
+  log('info', 'client connected', { docId, peers: doc.size });
 
   conn.on('message', (message) => {
-    // Relay to every other peer in the room — no parsing, no protocol knowledge.
-    for (const peer of room) {
+    // Relay to every other peer in the document — no parsing, no protocol knowledge.
+    for (const peer of doc) {
       if (peer !== conn && peer.readyState === WebSocket.OPEN) {
         peer.send(message);
       }
@@ -44,15 +44,15 @@ function setupWSConnection(conn, req) {
   });
 
   conn.on('close', () => {
-    room.delete(conn);
-    if (room.size === 0) rooms.delete(roomName);
-    log('info', 'client disconnected', { room: roomName, peers: room.size });
+    doc.delete(conn);
+    if (doc.size === 0) docs.delete(docId);
+    log('info', 'client disconnected', { docId, peers: doc.size });
   });
 
   conn.on('error', (err) => {
-    log('error', 'socket error', { room: roomName, error: err.message });
-    room.delete(conn);
-    if (room.size === 0) rooms.delete(roomName);
+    log('error', 'socket error', { docId, error: err.message });
+    doc.delete(conn);
+    if (doc.size === 0) docs.delete(docId);
   });
 }
 
@@ -60,8 +60,8 @@ function setupWSConnection(conn, req) {
 
 function getStats() {
   let clients = 0;
-  rooms.forEach(room => { clients += room.size; });
-  return { rooms: rooms.size, clients };
+  docs.forEach(doc => { clients += doc.size; });
+  return { docs: docs.size, clients };
 }
 
 // ─── Standalone server ────────────────────────────────────────────────────────

--- a/lib/collaborative.js
+++ b/lib/collaborative.js
@@ -21,6 +21,8 @@ function log(level, msg, extra) {
 
 const docs = new Map(); // docId → Set<WebSocket>
 
+const MAX_MESSAGE_BYTES = 1_048_576; // 1 MB
+
 // ─── Core connection handler ──────────────────────────────────────────────────
 
 function setupWSConnection(conn, req) {
@@ -32,9 +34,16 @@ function setupWSConnection(conn, req) {
   const doc = docs.get(docId);
   doc.add(conn);
 
+  conn.isAlive = true;
+  conn.on('pong', () => { conn.isAlive = true; });
+
   log('info', 'client connected', { docId, peers: doc.size });
 
   conn.on('message', (message) => {
+    if (message.length > MAX_MESSAGE_BYTES) {
+      log('warn', 'oversized message dropped', { docId, size: message.length });
+      return;
+    }
     // Relay to every other peer in the document — no parsing, no protocol knowledge.
     for (const peer of doc) {
       if (peer !== conn && peer.readyState === WebSocket.OPEN) {
@@ -54,6 +63,19 @@ function setupWSConnection(conn, req) {
     doc.delete(conn);
     if (doc.size === 0) docs.delete(docId);
   });
+}
+
+// ─── Keepalive heartbeat ──────────────────────────────────────────────────────
+
+function _startKeepalive(wss) {
+  const interval = setInterval(() => {
+    wss.clients.forEach(ws => {
+      if (!ws.isAlive) return ws.terminate();
+      ws.isAlive = false;
+      ws.ping();
+    });
+  }, 30_000);
+  wss.on('close', () => clearInterval(interval));
 }
 
 // ─── Stats (for /health) ──────────────────────────────────────────────────────
@@ -81,6 +103,7 @@ function createServer(options = {}) {
 
   const wss = new WebSocket.Server({ server: httpServer });
   wss.on('connection', setupWSConnection);
+  _startKeepalive(wss);
 
   const port = options.port || 3000;
   httpServer.listen(port, () => {
@@ -95,8 +118,11 @@ function createServer(options = {}) {
 function attachToServer(httpServer) {
   const wss = new WebSocket.Server({ server: httpServer });
   wss.on('connection', setupWSConnection);
+  _startKeepalive(wss);
   log('info', 'collaborative relay server attached to existing HTTP server');
   return wss;
 }
 
+// Exported as a named property so server.js can destructure:
+//   var Collaborative = FroalaEditor.Collaborative;
 exports.Collaborative = { setupWSConnection, createServer, attachToServer, getStats };

--- a/lib/froalaEditor.js
+++ b/lib/froalaEditor.js
@@ -5,7 +5,11 @@ var modules = [
   require('./file.js'),
   require('./image.js'),
   require('./s3.js'),
-  require('./video.js')
+  require('./video.js'),
+  require('./collaborative.js'),
+  require('./collab_persistence.js'),
+  require('./version_history.js'),
+  require('./async_save.js')
 ];
 
 // Merge modules functionalities.

--- a/lib/froalaEditor.js
+++ b/lib/froalaEditor.js
@@ -8,7 +8,7 @@ var modules = [
   require('./video.js'),
   require('./collaborative.js'),
   require('./collab_persistence.js'),
-  require('./version_history.js'),
+  require('./version_control.js'),
   require('./async_save.js')
 ];
 

--- a/lib/version_control.js
+++ b/lib/version_control.js
@@ -35,6 +35,8 @@ function _isNamed(title) {
 function attachRoutes(app, options) {
   options = options || {};
   const db = getDb(options.dbPath);
+  const auth = options.authMiddleware || function(req, res, next) { next(); };
+  app.use('/collab', auth);
 
   db.exec(`
     CREATE TABLE IF NOT EXISTS versions (
@@ -67,7 +69,9 @@ function attachRoutes(app, options) {
         .all(req.params.docId);
       ok(res, rows);
     } catch (err) {
-      bad(res, 500, err.message);
+      // eslint-disable-next-line no-console
+      console.error('[collab] db error:', err);
+      bad(res, 500, 'internal server error');
     }
   });
 
@@ -80,7 +84,9 @@ function attachRoutes(app, options) {
       if (!row) return bad(res, 404, 'version not found');
       ok(res, row);
     } catch (err) {
-      bad(res, 500, err.message);
+      // eslint-disable-next-line no-console
+      console.error('[collab] db error:', err);
+      bad(res, 500, 'internal server error');
     }
   });
 
@@ -116,7 +122,9 @@ function attachRoutes(app, options) {
       if (info.changes === 0) return bad(res, 409, 'version already exists');
       ok(res, { id }, 201);
     } catch (err) {
-      bad(res, 500, err.message);
+      // eslint-disable-next-line no-console
+      console.error('[collab] db error:', err);
+      bad(res, 500, 'internal server error');
     }
   });
 
@@ -151,7 +159,9 @@ function attachRoutes(app, options) {
       if (!row) return bad(res, 404, 'version not found');
       ok(res, row);
     } catch (err) {
-      bad(res, 500, err.message);
+      // eslint-disable-next-line no-console
+      console.error('[collab] db error:', err);
+      bad(res, 500, 'internal server error');
     }
   });
 
@@ -161,7 +171,9 @@ function attachRoutes(app, options) {
         .run(req.params.id, req.params.docId);
       res.sendStatus(204);
     } catch (err) {
-      bad(res, 500, err.message);
+      // eslint-disable-next-line no-console
+      console.error('[collab] db error:', err);
+      bad(res, 500, 'internal server error');
     }
   });
 }

--- a/lib/version_control.js
+++ b/lib/version_control.js
@@ -1,9 +1,9 @@
 'use strict';
 
-// ─── Version history persistence ─────────────────────────────────────────────
+// ─── Version control persistence ─────────────────────────────────────────────
 //
 // REST endpoints backed by SQLite for storing named/auto snapshots of editor
-// content per collaborative document. Used by the editor's CollabVersionHistory
+// content per collaborative document. Used by the editor's CollabVersionControl
 // sub-module in two flows:
 //
 //   • Real-time mode — mirror writes (best-effort POST) so peers joining
@@ -25,7 +25,7 @@ function _getDb(dbPath) {
     Database = require('better-sqlite3');
   } catch (err) {
     throw new Error(
-      '[version_history] better-sqlite3 is required. ' +
+      '[version_control] better-sqlite3 is required. ' +
       'Install it as a dev dependency: npm install --save-dev better-sqlite3'
     );
   }
@@ -79,7 +79,7 @@ function _isNamed(title) {
 // ─── Route registration ─────────────────────────────────────────────────────
 
 /**
- * Attach the version-history REST endpoints to an Express app.
+ * Attach the version-control REST endpoints to an Express app.
  *
  * @param {object} app          Express app instance
  * @param {object} [options]
@@ -205,4 +205,4 @@ function attachRoutes(app, options) {
   });
 }
 
-exports.VersionHistory = { attachRoutes };
+exports.VersionControl = { attachRoutes };

--- a/lib/version_control.js
+++ b/lib/version_control.js
@@ -15,62 +15,9 @@
 //   versions(id, doc_id, title, description, snapshot, created_at,
 //            author_id, author_name, is_named, source)
 
-let _db = null;
-
-function _getDb(dbPath) {
-  if (_db) return _db;
-
-  let Database;
-  try {
-    Database = require('better-sqlite3');
-  } catch (err) {
-    throw new Error(
-      '[version_control] better-sqlite3 is required. ' +
-      'Install it as a dev dependency: npm install --save-dev better-sqlite3'
-    );
-  }
-
-  _db = new Database(dbPath || 'collab.db');
-  _db.pragma('journal_mode = WAL');
-
-  _db.exec(`
-    CREATE TABLE IF NOT EXISTS versions (
-      id TEXT PRIMARY KEY,
-      doc_id TEXT NOT NULL,
-      title TEXT,
-      description TEXT,
-      snapshot TEXT NOT NULL,
-      created_at INTEGER NOT NULL,
-      author_id TEXT,
-      author_name TEXT,
-      is_named INTEGER DEFAULT 0,
-      source TEXT DEFAULT 'manual'
-    );
-
-    CREATE INDEX IF NOT EXISTS idx_versions_doc_id ON versions(doc_id);
-  `);
-
-  return _db;
-}
+const { getDb, ok, bad, generateId } = require('./collab_db');
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
-
-function _ok(res, body, code) {
-  res.status(code || 200).json(body);
-}
-
-function _bad(res, code, msg) {
-  res.status(code).json({ error: msg });
-}
-
-function _generateId() {
-  return (
-    'rv-' +
-    Date.now().toString(36) +
-    '-' +
-    Math.random().toString(36).slice(2, 7)
-  );
-}
 
 function _isNamed(title) {
   return title != null && String(title).trim() !== '' ? 1 : 0;
@@ -87,7 +34,24 @@ function _isNamed(title) {
  */
 function attachRoutes(app, options) {
   options = options || {};
-  const db = _getDb(options.dbPath);
+  const db = getDb(options.dbPath);
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS versions (
+      id TEXT PRIMARY KEY,
+      doc_id TEXT NOT NULL,
+      title TEXT,
+      description TEXT,
+      snapshot TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      author_id TEXT,
+      author_name TEXT,
+      is_named INTEGER DEFAULT 0,
+      source TEXT DEFAULT 'manual'
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_versions_doc_id ON versions(doc_id);
+  `);
 
   // List versions for a document (excludes snapshot for list-view performance).
   app.get('/collab/:docId/versions', (req, res) => {
@@ -101,9 +65,9 @@ function attachRoutes(app, options) {
           ORDER BY created_at DESC
         `)
         .all(req.params.docId);
-      _ok(res, rows);
+      ok(res, rows);
     } catch (err) {
-      _bad(res, 500, err.message);
+      bad(res, 500, err.message);
     }
   });
 
@@ -113,26 +77,26 @@ function attachRoutes(app, options) {
       const row = db
         .prepare('SELECT * FROM versions WHERE id = ? AND doc_id = ?')
         .get(req.params.id, req.params.docId);
-      if (!row) return _bad(res, 404, 'version not found');
-      _ok(res, row);
+      if (!row) return bad(res, 404, 'version not found');
+      ok(res, row);
     } catch (err) {
-      _bad(res, 500, err.message);
+      bad(res, 500, err.message);
     }
   });
 
   // Create a new version. Server fills id if missing; snapshot is required.
   app.post('/collab/:docId/versions', (req, res) => {
     const v = req.body || {};
-    if (v.snapshot == null) return _bad(res, 400, 'snapshot is required');
+    if (v.snapshot == null) return bad(res, 400, 'snapshot is required');
 
-    const id = v.id || _generateId();
+    const id = v.id || generateId('rv');
     const title = v.title == null ? null : String(v.title);
     const description = v.description == null ? null : String(v.description);
     const author = v.author || {};
     const source = v.source === 'auto' ? 'auto' : 'manual';
 
     try {
-      db.prepare(`
+      const info = db.prepare(`
         INSERT OR IGNORE INTO versions
         (id, doc_id, title, description, snapshot, created_at,
          author_id, author_name, is_named, source)
@@ -143,19 +107,16 @@ function attachRoutes(app, options) {
         title,
         description,
         v.snapshot,
-        v.createdAt || Date.now(),
+        Date.now(),
         author.id || null,
         author.name || null,
         _isNamed(title),
         source
       );
-
-      const row = db
-        .prepare('SELECT * FROM versions WHERE id = ? AND doc_id = ?')
-        .get(id, req.params.docId);
-      _ok(res, row, 201);
+      if (info.changes === 0) return bad(res, 409, 'version already exists');
+      ok(res, { id }, 201);
     } catch (err) {
-      _bad(res, 500, err.message);
+      bad(res, 500, err.message);
     }
   });
 
@@ -165,7 +126,7 @@ function attachRoutes(app, options) {
     const hasTitle = 'title' in body;
     const hasDesc = 'description' in body;
     if (!hasTitle && !hasDesc) {
-      return _bad(res, 400, 'title or description required');
+      return bad(res, 400, 'title or description required');
     }
 
     try {
@@ -187,10 +148,10 @@ function attachRoutes(app, options) {
       const row = db
         .prepare('SELECT * FROM versions WHERE id = ? AND doc_id = ?')
         .get(req.params.id, req.params.docId);
-      if (!row) return _bad(res, 404, 'version not found');
-      _ok(res, row);
+      if (!row) return bad(res, 404, 'version not found');
+      ok(res, row);
     } catch (err) {
-      _bad(res, 500, err.message);
+      bad(res, 500, err.message);
     }
   });
 
@@ -200,9 +161,11 @@ function attachRoutes(app, options) {
         .run(req.params.id, req.params.docId);
       res.sendStatus(204);
     } catch (err) {
-      _bad(res, 500, err.message);
+      bad(res, 500, err.message);
     }
   });
 }
 
+// Exported as a named property so server.js can destructure:
+//   var VersionControl = FroalaEditor.VersionControl;
 exports.VersionControl = { attachRoutes };

--- a/lib/version_history.js
+++ b/lib/version_history.js
@@ -1,0 +1,208 @@
+'use strict';
+
+// ─── Version history persistence ─────────────────────────────────────────────
+//
+// REST endpoints backed by SQLite for storing named/auto snapshots of editor
+// content per collaborative room. Used by the editor's CollabVersionHistory
+// sub-module in two flows:
+//
+//   • Real-time mode — mirror writes (best-effort POST) so peers joining
+//     without Yjs history can still bootstrap the version list.
+//   • Offline mode  — sole source of truth; every save/list/restore call
+//     lands directly here.
+//
+// Table (auto-created on first call to `attachRoutes`):
+//   versions(id, room, title, description, snapshot, created_at,
+//            author_id, author_name, is_named, source)
+
+let _db = null;
+
+function _getDb(dbPath) {
+  if (_db) return _db;
+
+  let Database;
+  try {
+    Database = require('better-sqlite3');
+  } catch (err) {
+    throw new Error(
+      '[version_history] better-sqlite3 is required. ' +
+      'Install it as a dev dependency: npm install --save-dev better-sqlite3'
+    );
+  }
+
+  _db = new Database(dbPath || 'collab.db');
+  _db.pragma('journal_mode = WAL');
+
+  _db.exec(`
+    CREATE TABLE IF NOT EXISTS versions (
+      id TEXT PRIMARY KEY,
+      room TEXT NOT NULL,
+      title TEXT,
+      description TEXT,
+      snapshot TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      author_id TEXT,
+      author_name TEXT,
+      is_named INTEGER DEFAULT 0,
+      source TEXT DEFAULT 'manual'
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_versions_room ON versions(room);
+  `);
+
+  return _db;
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function _ok(res, body, code) {
+  res.status(code || 200).json(body);
+}
+
+function _bad(res, code, msg) {
+  res.status(code).json({ error: msg });
+}
+
+function _generateId() {
+  return (
+    'rv-' +
+    Date.now().toString(36) +
+    '-' +
+    Math.random().toString(36).slice(2, 7)
+  );
+}
+
+function _isNamed(title) {
+  return title != null && String(title).trim() !== '' ? 1 : 0;
+}
+
+// ─── Route registration ─────────────────────────────────────────────────────
+
+/**
+ * Attach the version-history REST endpoints to an Express app.
+ *
+ * @param {object} app          Express app instance
+ * @param {object} [options]
+ * @param {string} [options.dbPath='collab.db']  SQLite file path
+ */
+function attachRoutes(app, options) {
+  options = options || {};
+  const db = _getDb(options.dbPath);
+
+  // List versions for a room (excludes snapshot for list-view performance).
+  app.get('/collab/:room/versions', (req, res) => {
+    try {
+      const rows = db
+        .prepare(`
+          SELECT id, room, title, description, created_at,
+                 author_id, author_name, is_named, source
+          FROM versions
+          WHERE room = ?
+          ORDER BY created_at DESC
+        `)
+        .all(req.params.room);
+      _ok(res, rows);
+    } catch (err) {
+      _bad(res, 500, err.message);
+    }
+  });
+
+  // Fetch a single version including the full snapshot.
+  app.get('/collab/:room/versions/:id', (req, res) => {
+    try {
+      const row = db
+        .prepare('SELECT * FROM versions WHERE id = ? AND room = ?')
+        .get(req.params.id, req.params.room);
+      if (!row) return _bad(res, 404, 'version not found');
+      _ok(res, row);
+    } catch (err) {
+      _bad(res, 500, err.message);
+    }
+  });
+
+  // Create a new version. Server fills id if missing; snapshot is required.
+  app.post('/collab/:room/versions', (req, res) => {
+    const v = req.body || {};
+    if (v.snapshot == null) return _bad(res, 400, 'snapshot is required');
+
+    const id = v.id || _generateId();
+    const title = v.title == null ? null : String(v.title);
+    const description = v.description == null ? null : String(v.description);
+    const author = v.author || {};
+    const source = v.source === 'auto' ? 'auto' : 'manual';
+
+    try {
+      db.prepare(`
+        INSERT OR IGNORE INTO versions
+        (id, room, title, description, snapshot, created_at,
+         author_id, author_name, is_named, source)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        id,
+        req.params.room,
+        title,
+        description,
+        v.snapshot,
+        v.createdAt || Date.now(),
+        author.id || null,
+        author.name || null,
+        _isNamed(title),
+        source
+      );
+
+      const row = db
+        .prepare('SELECT * FROM versions WHERE id = ? AND room = ?')
+        .get(id, req.params.room);
+      _ok(res, row, 201);
+    } catch (err) {
+      _bad(res, 500, err.message);
+    }
+  });
+
+  // Update title and/or description. Recomputes is_named when title changes.
+  app.patch('/collab/:room/versions/:id', (req, res) => {
+    const body = req.body || {};
+    const hasTitle = 'title' in body;
+    const hasDesc = 'description' in body;
+    if (!hasTitle && !hasDesc) {
+      return _bad(res, 400, 'title or description required');
+    }
+
+    try {
+      if (hasTitle) {
+        const title = body.title == null ? null : String(body.title);
+        db.prepare(`
+          UPDATE versions SET title = ?, is_named = ?
+          WHERE id = ? AND room = ?
+        `).run(title, _isNamed(title), req.params.id, req.params.room);
+      }
+      if (hasDesc) {
+        const description = body.description == null ? null : String(body.description);
+        db.prepare(`
+          UPDATE versions SET description = ?
+          WHERE id = ? AND room = ?
+        `).run(description, req.params.id, req.params.room);
+      }
+
+      const row = db
+        .prepare('SELECT * FROM versions WHERE id = ? AND room = ?')
+        .get(req.params.id, req.params.room);
+      if (!row) return _bad(res, 404, 'version not found');
+      _ok(res, row);
+    } catch (err) {
+      _bad(res, 500, err.message);
+    }
+  });
+
+  app.delete('/collab/:room/versions/:id', (req, res) => {
+    try {
+      db.prepare('DELETE FROM versions WHERE id = ? AND room = ?')
+        .run(req.params.id, req.params.room);
+      res.sendStatus(204);
+    } catch (err) {
+      _bad(res, 500, err.message);
+    }
+  });
+}
+
+exports.VersionHistory = { attachRoutes };

--- a/lib/version_history.js
+++ b/lib/version_history.js
@@ -3,7 +3,7 @@
 // ─── Version history persistence ─────────────────────────────────────────────
 //
 // REST endpoints backed by SQLite for storing named/auto snapshots of editor
-// content per collaborative room. Used by the editor's CollabVersionHistory
+// content per collaborative document. Used by the editor's CollabVersionHistory
 // sub-module in two flows:
 //
 //   • Real-time mode — mirror writes (best-effort POST) so peers joining
@@ -12,7 +12,7 @@
 //     lands directly here.
 //
 // Table (auto-created on first call to `attachRoutes`):
-//   versions(id, room, title, description, snapshot, created_at,
+//   versions(id, doc_id, title, description, snapshot, created_at,
 //            author_id, author_name, is_named, source)
 
 let _db = null;
@@ -36,7 +36,7 @@ function _getDb(dbPath) {
   _db.exec(`
     CREATE TABLE IF NOT EXISTS versions (
       id TEXT PRIMARY KEY,
-      room TEXT NOT NULL,
+      doc_id TEXT NOT NULL,
       title TEXT,
       description TEXT,
       snapshot TEXT NOT NULL,
@@ -47,7 +47,7 @@ function _getDb(dbPath) {
       source TEXT DEFAULT 'manual'
     );
 
-    CREATE INDEX IF NOT EXISTS idx_versions_room ON versions(room);
+    CREATE INDEX IF NOT EXISTS idx_versions_doc_id ON versions(doc_id);
   `);
 
   return _db;
@@ -89,18 +89,18 @@ function attachRoutes(app, options) {
   options = options || {};
   const db = _getDb(options.dbPath);
 
-  // List versions for a room (excludes snapshot for list-view performance).
-  app.get('/collab/:room/versions', (req, res) => {
+  // List versions for a document (excludes snapshot for list-view performance).
+  app.get('/collab/:docId/versions', (req, res) => {
     try {
       const rows = db
         .prepare(`
-          SELECT id, room, title, description, created_at,
+          SELECT id, doc_id, title, description, created_at,
                  author_id, author_name, is_named, source
           FROM versions
-          WHERE room = ?
+          WHERE doc_id = ?
           ORDER BY created_at DESC
         `)
-        .all(req.params.room);
+        .all(req.params.docId);
       _ok(res, rows);
     } catch (err) {
       _bad(res, 500, err.message);
@@ -108,11 +108,11 @@ function attachRoutes(app, options) {
   });
 
   // Fetch a single version including the full snapshot.
-  app.get('/collab/:room/versions/:id', (req, res) => {
+  app.get('/collab/:docId/versions/:id', (req, res) => {
     try {
       const row = db
-        .prepare('SELECT * FROM versions WHERE id = ? AND room = ?')
-        .get(req.params.id, req.params.room);
+        .prepare('SELECT * FROM versions WHERE id = ? AND doc_id = ?')
+        .get(req.params.id, req.params.docId);
       if (!row) return _bad(res, 404, 'version not found');
       _ok(res, row);
     } catch (err) {
@@ -121,7 +121,7 @@ function attachRoutes(app, options) {
   });
 
   // Create a new version. Server fills id if missing; snapshot is required.
-  app.post('/collab/:room/versions', (req, res) => {
+  app.post('/collab/:docId/versions', (req, res) => {
     const v = req.body || {};
     if (v.snapshot == null) return _bad(res, 400, 'snapshot is required');
 
@@ -134,12 +134,12 @@ function attachRoutes(app, options) {
     try {
       db.prepare(`
         INSERT OR IGNORE INTO versions
-        (id, room, title, description, snapshot, created_at,
+        (id, doc_id, title, description, snapshot, created_at,
          author_id, author_name, is_named, source)
         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `).run(
         id,
-        req.params.room,
+        req.params.docId,
         title,
         description,
         v.snapshot,
@@ -151,8 +151,8 @@ function attachRoutes(app, options) {
       );
 
       const row = db
-        .prepare('SELECT * FROM versions WHERE id = ? AND room = ?')
-        .get(id, req.params.room);
+        .prepare('SELECT * FROM versions WHERE id = ? AND doc_id = ?')
+        .get(id, req.params.docId);
       _ok(res, row, 201);
     } catch (err) {
       _bad(res, 500, err.message);
@@ -160,7 +160,7 @@ function attachRoutes(app, options) {
   });
 
   // Update title and/or description. Recomputes is_named when title changes.
-  app.patch('/collab/:room/versions/:id', (req, res) => {
+  app.patch('/collab/:docId/versions/:id', (req, res) => {
     const body = req.body || {};
     const hasTitle = 'title' in body;
     const hasDesc = 'description' in body;
@@ -173,20 +173,20 @@ function attachRoutes(app, options) {
         const title = body.title == null ? null : String(body.title);
         db.prepare(`
           UPDATE versions SET title = ?, is_named = ?
-          WHERE id = ? AND room = ?
-        `).run(title, _isNamed(title), req.params.id, req.params.room);
+          WHERE id = ? AND doc_id = ?
+        `).run(title, _isNamed(title), req.params.id, req.params.docId);
       }
       if (hasDesc) {
         const description = body.description == null ? null : String(body.description);
         db.prepare(`
           UPDATE versions SET description = ?
-          WHERE id = ? AND room = ?
-        `).run(description, req.params.id, req.params.room);
+          WHERE id = ? AND doc_id = ?
+        `).run(description, req.params.id, req.params.docId);
       }
 
       const row = db
-        .prepare('SELECT * FROM versions WHERE id = ? AND room = ?')
-        .get(req.params.id, req.params.room);
+        .prepare('SELECT * FROM versions WHERE id = ? AND doc_id = ?')
+        .get(req.params.id, req.params.docId);
       if (!row) return _bad(res, 404, 'version not found');
       _ok(res, row);
     } catch (err) {
@@ -194,10 +194,10 @@ function attachRoutes(app, options) {
     }
   });
 
-  app.delete('/collab/:room/versions/:id', (req, res) => {
+  app.delete('/collab/:docId/versions/:id', (req, res) => {
     try {
-      db.prepare('DELETE FROM versions WHERE id = ? AND room = ?')
-        .run(req.params.id, req.params.room);
+      db.prepare('DELETE FROM versions WHERE id = ? AND doc_id = ?')
+        .run(req.params.id, req.params.docId);
       res.sendStatus(204);
     } catch (err) {
       _bad(res, 500, err.message);

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://www.froala.com/wysiwyg-editor",
   "dependencies": {
+    "better-sqlite3": "^12.10.0",
     "busboy": "~0.2.13",
     "crypto-js": "^3.1.6",
     "gm": "^1.23.0",
@@ -31,7 +32,6 @@
     "ws": "^8.20.0"
   },
   "devDependencies": {
-    "better-sqlite3": "^12.10.0",
     "body-parser": "^1.15.2",
     "express": "~4.17.1"
   }

--- a/package.json
+++ b/package.json
@@ -27,9 +27,11 @@
     "crypto-js": "^3.1.6",
     "gm": "^1.23.0",
     "merge": "~2.1.1",
-    "sha1": "~1.1.1"
+    "sha1": "~1.1.1",
+    "ws": "^8.20.0"
   },
   "devDependencies": {
+    "better-sqlite3": "^12.10.0",
     "body-parser": "^1.15.2",
     "express": "~4.17.1"
   }


### PR DESCRIPTION
## Description

This PR adds backend support for **Real-time Collaboration, Suggestions & Comments, Version History, and Async Save** to the Froala Node SDK, along with a complete Collaborative demo app.

## Related Links

- https://iderawebdev.atlassian.net/browse/FROALA-724
- https://iderawebdev.atlassian.net/browse/FROALA-723

## Changes Made

**Backend (lib/)**
- [x] `collaborative.js` — WebSocket relay server with room-based broadcasting; runs standalone or attached to an existing Express/HTTP server, with a `getStats()` helper for room/client counts.
- [x] `collab_persistence.js` — SQLite-backed REST endpoints (CRUD) for suggestions and comments under `/collab/:room/...`.
- [x] `version_history.js` — REST endpoints to save, list, fetch, and restore named/auto version snapshots per room.
- [x] `async_save.js` — Upserts the latest editor content per room (`POST/GET /collab/:room/content`) for async/offline mode (when `realTimeConfig.syncUrl` is not set).
- [x] Registered all four modules in `froalaEditor.js` alongside the existing Image, File, Video, and S3 modules.

**Collaborative Demo (examples/collaborative/)**
- [x] New demo app (`index.html`, `editor.html`, `main.js`, `style.css`): a launcher to pick user, role, and room, and an editor page wired to the collaborative plugin.
- [x] Supports both **realtime mode** (WebSocket sync via `realTimeConfig.syncUrl`) and **async mode** (periodic save to `/collab/:room/content` with content restore on load), plus optional version history, auto-save interval, and mentionable users via URL params.
- [x] Linked the demo from `examples/index.html`.

**Examples Server & Housekeeping**
- [x] Updated `examples/server.js`: dev CORS, persistence/version-history/async-save routes on a shared `collab.db`, WebSocket relay sharing port 3000, and a `GET /health` endpoint.
- [x] Added `ws@^8.20.0` dependency (`better-sqlite3` required as a dev dependency); ignored `package-lock.json` and `collab.db**`.

## How to Test

1. `npm install`
2. `bower install` to install the editor assets.
3. Run `npm start` and open the Collaborative demo.
4. Join the same room from two tabs — edits and cursors sync live; try async mode, suggestions/comments, and version history to verify persistence in `collab.db`.
